### PR TITLE
Filter for OpenStack project

### DIFF
--- a/ci/tasks/cleanup.sh
+++ b/ci/tasks/cleanup.sh
@@ -6,6 +6,12 @@ source bosh-cpi-src-in/ci/tasks/utils.sh
 
 init_openstack_cli_env
 
+OPENSTACK_PROJECT_ID=$(openstack project list --format json | jq --raw-output --arg project $BOSH_OPENSTACK_PROJECT '.[] | select(.Name == $project) | .ID')
+if [ -z "$OPENSTACK_PROJECT_ID" ]; then
+  echo "Error: Failed to get OpenStack project"
+  exit 1
+fi
+
 exit_code=0
 
 openstack_delete_entities() {
@@ -22,16 +28,17 @@ openstack_delete_entities() {
 }
 
 openstack_delete_ports() {
-  for port in $(openstack port list --format json | jq --raw-output '.[].ID')
+  for port in $(openstack port list --project=$OPENSTACK_PROJECT_ID -c ID -f value)
   do
 
   # don't delete ports that are:
   # 'network:floatingip', 'network:router_gateway',
   # 'network:dhcp', 'network:router_interface',
   # 'network:ha_router_replicated_interface',
+  # 'network:router_interface_distributed',
   # 'neutron:LOADBALANCERV2' and 'network:f5lbaasv2'
   # Maybe we could just filter for 'network:'?
-    port_to_be_deleted=`openstack port show --format json $port | jq --raw-output '. | select(.device_owner | contains("network:floatingip") or contains("network:router_gateway") or contains("network:dhcp") or contains("network:router_interface") or contains("network:ha_router_replicated_interface") or contains("neutron:LOADBALANCERV2") or contains("network:f5lbaasv2") or contains("network:router_centralized_snat") | not ) | .id'`
+    port_to_be_deleted=`openstack port show --format json $port | jq --raw-output '. | select(.device_owner | contains("network:floatingip") or contains("network:router_gateway") or contains("network:dhcp") or contains("network:router_interface") or contains("network:ha_router_replicated_interface") or contains("neutron:LOADBALANCERV2") or contains("network:f5lbaasv2") or contains("network:router_centralized_snat") or contains("network:router_interface_distributed") | not ) | .id'`
     if [ ! -z ${port_to_be_deleted} ];
     then
       echo "Deleting port ${port_to_be_deleted}"
@@ -48,7 +55,7 @@ openstack --version
 echo "Deleting servers #########################"
 openstack_delete_entities "server"
 echo "Deleting images #########################"
-openstack_delete_entities "image" "--private --limit 1000"
+openstack_delete_entities "image" "--private --limit 1000 --property owner=$OPENSTACK_PROJECT_ID"
 echo "Deleting snapshots #########################"
 openstack_delete_entities "snapshot"
 echo "Deleting volumes #########################"


### PR DESCRIPTION
If the user running the CFOV has an admin role on the project
the validator runs in, the cleanup script will find all glance
images and all neutron ports.
The list commands filters by default on the project for servers, volumes
and snapshot.
This patch adds the project filter explicitely for images and ports.
If we cannot retrieve the OpenStack project ID, we exit. Because we
would delete to many ports, if run as admin user.

Additionally we filter the neutron port list for DVR ports.
(Maybe a whitelist for device_owner=compute:* is better here?)