### PR TITLE
Move periodic jobs back to OpenLab

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -7,18 +7,6 @@
         - bosh-openstack-cpi-release-acceptance-test-queens
         - bosh-openstack-cpi-release-acceptance-test-pike
         - bosh-openstack-cpi-release-acceptance-test-ocata
-    periodic:
-      jobs:
-        - bosh-openstack-cpi-release-acceptance-test:
-            branches: master
-        - bosh-openstack-cpi-release-acceptance-test-rocky:
-            branches: master
-        - bosh-openstack-cpi-release-acceptance-test-queens:
-            branches: master
-        - bosh-openstack-cpi-release-acceptance-test-pike:
-            branches: master
-        - bosh-openstack-cpi-release-acceptance-test-ocata:
-            branches: master
 
 - job:
     name: bosh-openstack-cpi-release-acceptance-test


### PR DESCRIPTION
We hope to move all of outside periodic jobs back to OpenLab
projects.yaml, so that we can plan the periodic testing resource
usage amount for OpenLab and avoid periodic jobs define confusion
in different project branch maintaining policy. Periodic jobs will
be moved to theopenlab/openlab-zuul-jobs#479 and will be triggered
at UTC-0 04:00 and 16:00 of everyday.

Related-Bug: theopenlab/openlab#173