### PR TITLE
Add cck tests skipping for centos vms

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -298,6 +298,7 @@ jobs:
           bosh_vcap_password:                       ((bosh_vcap_password))
           availability_zone:                        ((availability_zone))
           DEBUG_BATS:                               *debug_bats
+          bats_rspec_tags:                          ""
         <<: *send-failure-email
         ensure:
           task: print-task-errors
@@ -400,6 +401,7 @@ jobs:
           private_key_data:                         ((bosh_private_key))
           availability_zone:                        ((availability_zone))
           DEBUG_BATS:                               *debug_bats
+          bats_rspec_tags:                          ""
         <<: *send-failure-email
         ensure:
           task: print-task-errors
@@ -505,6 +507,7 @@ jobs:
           bosh_vcap_password:                       ((bosh_vcap_password))
           availability_zone:                        ((availability_zone))
           DEBUG_BATS:                               *debug_bats
+          bats_rspec_tags:                          "--tag ~skip_centos"
         <<: *send-failure-email
         ensure:
           task: print-task-errors
@@ -606,6 +609,7 @@ jobs:
           private_key_data:                         ((bosh_private_key))
           availability_zone:                        ((availability_zone))
           DEBUG_BATS:                               *debug_bats
+          bats_rspec_tags:                          "--tag ~skip_centos"
         <<: *send-failure-email
         ensure:
           task: print-task-errors

--- a/ci/tasks/run-dynamic-networking-bats.sh
+++ b/ci/tasks/run-dynamic-networking-bats.sh
@@ -9,6 +9,7 @@ source bosh-cpi-src-in/ci/tasks/utils.sh
 : ${openstack_flavor_with_ephemeral_disk:?}
 : ${openstack_flavor_with_no_ephemeral_disk:?}
 : ${private_key_data:?}
+: ${bats_rspec_tags:?}
 
 optional_value availability_zone
 
@@ -80,4 +81,4 @@ EOF
 
 cd bats
 bundle install -j4
-bundle exec rspec --tag ~manual_networking --tag ~raw_ephemeral_storage spec
+bundle exec rspec --tag ~manual_networking --tag ~raw_ephemeral_storage ${bats_rspec_tags} spec

--- a/ci/tasks/run-dynamic-networking-bats.yml
+++ b/ci/tasks/run-dynamic-networking-bats.yml
@@ -21,3 +21,4 @@ params:
   private_key_data:                          replace-me
   stemcell_name:                             replace-me
   availability_zone:                         replace-me
+  bats_rspec_tags:                           ""

--- a/ci/tasks/run-manual-networking-bats.sh
+++ b/ci/tasks/run-manual-networking-bats.sh
@@ -9,6 +9,7 @@ source bosh-cpi-src-in/ci/tasks/utils.sh
 : ${openstack_flavor_with_ephemeral_disk:?}
 : ${openstack_flavor_with_no_ephemeral_disk:?}
 : ${private_key_data:?}
+: ${bats_rspec_tags:?}
 
 optional_value availability_zone
 
@@ -113,4 +114,4 @@ EOF
 
 cd bats
 bundle install -j4
-bundle exec rspec --tag ~raw_ephemeral_storage --tag ~multiple_manual_networks spec
+bundle exec rspec --tag ~raw_ephemeral_storage --tag ~multiple_manual_networks ${bats_rspec_tags} spec

--- a/ci/tasks/run-manual-networking-bats.yml
+++ b/ci/tasks/run-manual-networking-bats.yml
@@ -21,3 +21,4 @@ params:
   bosh_vcap_password:                       replace-me
   private_key_data:                         replace-me
   availability_zone:                        replace-me
+  bats_rspec_tags:                          ""


### PR DESCRIPTION
CCK tests can't be run on centos stemcells at the moment.
This change allows that centos tests skip the cck suite, but it will
still run in ubuntu-based stemcells.