### PR TITLE
Fix broken offline environment create-env

### DIFF
--- a/packages/bosh_openstack_cpi/packaging
+++ b/packages/bosh_openstack_cpi/packaging
@@ -9,12 +9,11 @@ source "${BOSH_PACKAGES_DIR}/ruby-3.1.0-r0.81.0/bosh/compile.env"
 cp -a bosh_openstack_cpi/* "${BOSH_INSTALL_TARGET}"
 
 export BUNDLE_CACHE_PATH="vendor/package"
-export BUNDLE_WITHOUT="development:test"
 bundle_cmd="$BOSH_PACKAGES_DIR/ruby-3.1.0-r0.81.0/bin/bundle"
+$bundle_cmd config set --local deployment 'true'
+$bundle_cmd config set --local no_prune 'true'
+$bundle_cmd config set --local without 'development test'
 
 cd "${BOSH_INSTALL_TARGET}"
 
-$bundle_cmd install \
-  --local           \
-  --no-prune        \
-  --deployment
+$bundle_cmd install

--- a/packages/bosh_openstack_cpi/pre_packaging
+++ b/packages/bosh_openstack_cpi/pre_packaging
@@ -4,7 +4,7 @@ set -ex
 
 export BUNDLE_APP_CONFIG=$(mktemp -d $TMPDIR/bundler_config_XXXXXX)
 export BUNDLE_CACHE_PATH="vendor/package"
-export BUNDLE_WITHOUT="development:test"
+bundle config set --local without 'development test'
 
 pushd ${BUILD_DIR}/bosh_openstack_cpi
   bundle package --all-platforms --no-install


### PR DESCRIPTION
bundler stopped picking up some cli flags and some env vars. there have
been warnings around this but we do not see them when the create-env
succeeds. It wasn't caught in CI since the CI environment is not
internetless. In that case bundler was still able to reach out to get the
gems that were already present locally (which it ignored because it
ignored the cli flags)

fixes:

```
Finished installing CPI (00:03:11)
Cleaning up rendered CPI jobs... Finished (00:00:00)
Error getting CPI info:
  Executing external CPI command: '/home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/jobs/openstack_cpi/bin/cpi':
    Running command: '/home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/jobs/openstack_cpi/bin/cpi', stdout: '', stderr: 'bundler: failed to load command: /home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/packages/bosh_openstack_cpi/bin/openstack_cpi (/home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/packages/bosh_openstack_cpi/bin/openstack_cpi)
/home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/packages/ruby-3.1.0-r0.81.0/lib/ruby/site_ruby/3.1.0/bundler/definition.rb:481:in `materialize': Could not find bosh_common-1.3262.24.0, bosh_cpi-2.5.0, excon-0.71.1, fog-openstack-1.1.0, httpclient-2.8.3, membrane-1.1.0, netaddr-2.0.5, logging-1.8.2, semi_semantic-1.2.0, fog-core-2.2.4, fog-json-1.2.0, ipaddress-0.8.3, little-plugger-1.1.4, multi_json-1.15.0, builder-3.2.4, formatador-0.3.0, mime-types-3.4.1, mime-types-data-3.2022.0105 in any of the sources (Bundler::GemNotFound)
from /home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/packages/ruby-3.1.0-r0.81.0/lib/ruby/site_ruby/3.1.0/bundler/definition.rb:190:in `specs'
from /home/tempest-web/.bosh/installations/22a68df8-5b95-4b3c-41a4-4f2dd8dab4e7/packages/ruby-3.1.0-r0.81.0/lib/ruby/site_ruby/3.1.0/bundler/definition.rb:238:in `specs_for'
```

Signed-off-by: jpalermo <jpalermo@vmware.com>