### PR TITLE
Fixes for running the cpi in an internetless environment

### DIFF
--- a/packages/bosh_openstack_cpi/packaging
+++ b/packages/bosh_openstack_cpi/packaging
@@ -10,6 +10,7 @@ cp -a bosh_openstack_cpi/* "${BOSH_INSTALL_TARGET}"
 cd "${BOSH_INSTALL_TARGET}"
 
 bundle_cmd="$BOSH_PACKAGES_DIR/ruby-3.1/bin/bundle"
+export BUNDLER_VERSION="$($bundle_cmd -v | grep -o -e '[0-9.]*')"
 $bundle_cmd config set --local deployment 'true'
 $bundle_cmd config set --local no_prune 'true'
 $bundle_cmd config set --local without 'development test'

--- a/src/bosh_openstack_cpi/Gemfile.lock
+++ b/src/bosh_openstack_cpi/Gemfile.lock
@@ -19,10 +19,10 @@ GEM
       rexml
     diff-lcs (1.5.0)
     excon (0.71.1)
-    fog-core (2.2.4)
+    fog-core (2.3.0)
       builder
       excon (~> 0.71)
-      formatador (~> 0.2)
+      formatador (>= 0.2, < 2.0)
       mime-types
     fog-json (1.2.0)
       fog-core
@@ -30,11 +30,9 @@ GEM
     fog-openstack (1.1.0)
       fog-core (~> 2.1)
       fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    formatador (0.3.0)
+    formatador (1.1.0)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    ipaddress (0.8.3)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
@@ -124,4 +122,4 @@ DEPENDENCIES
   webmock (~> 3.14.0)
 
 BUNDLED WITH
-   2.3.7
+   2.3.11


### PR DESCRIPTION
We now specify BUNDLER_VERSION to prevent bundler from trying to install the version specified by BUNDLED WITH in the Gemfile.lock. Since we use the bundler from the ruby package, these versions are not likely to match.

This does not cause it to error in internetless environments, but it does hang for a long time before timing out and simply using the current bundler.

---

The Gemfile.lock was in a bad state causing this error:
`Could not find ipaddress-0.8.3 in locally installed gems`
which we are seeing in internetless environments.