### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/src/bosh_openstack_cpi/Gemfile.lock
+++ b/src/bosh_openstack_cpi/Gemfile.lock
@@ -19,10 +19,10 @@ GEM
       rexml
     diff-lcs (1.5.0)
     excon (0.71.1)
-    fog-core (2.2.4)
+    fog-core (2.3.0)
       builder
       excon (~> 0.71)
-      formatador (~> 0.2)
+      formatador (>= 0.2, < 2.0)
       mime-types
     fog-json (1.2.0)
       fog-core
@@ -30,11 +30,9 @@ GEM
     fog-openstack (1.1.0)
       fog-core (~> 2.1)
       fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    formatador (0.3.0)
+    formatador (1.1.0)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    ipaddress (0.8.3)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)


### PR DESCRIPTION
It appears that the prior commit which updated `fog-openstack` to 1.1.0 did not do so by executing `bundle update fog-openstack`. When one explicitly runs this command, the Gemfile.lock pulls many updates to match the fog-openstack dependencies (including the removal of ipaddress, which has caused some odd problems in environments without internet connectivity). This commit checks in the result of Gemfile.lock after running the proper `bundle update` command.

Also see my comments on https://github.com/cloudfoundry/bosh-openstack-cpi-release/pull/256