### PR TITLE
Remove blobstore info from IaaS metadata endpoints

### DIFF
--- a/ci/templates/jobs/openstack_cpi/spec.erb
+++ b/ci/templates/jobs/openstack_cpi/spec.erb
@@ -102,61 +102,9 @@ properties:
     description: List of NTP servers
     example: ["0.us.pool.ntp.org", "1.us.pool.ntp.org"]
 
-  agent.blobstore.access_key_id:
-    description: access_key_id for agent used by s3 blobstore plugin
-  agent.blobstore.secret_access_key:
-    description: secret_access_key for agent used by s3 blobstore plugin
   agent.mbus:
     description: Message bus endpoint for the agent to start accepting agent requests
     example: https://user:password@192.168.0.1:5000
-  agent.blobstore.address:
-    description: Address for agent to connect to blobstore server used by 'dav' blobstore plugin
-  agent.blobstore.use_ssl:
-    description: Whether the agent blobstore plugin should use SSL to connect to the blobstore server
-  agent.blobstore.s3_region:
-    description: AWS region for agent used by s3 blobstore plugin
-  agent.blobstore.s3_port:
-    description: Port of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.host:
-    description: Host of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.ssl_verify_peer:
-    description: Whether the agent blobstore plugin should verify its peer when using SSL
-  agent.blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-
-  blobstore.address:
-    description: Address for agent to connect to blobstore server used by 'dav' blobstore plugin
-  blobstore.port:
-    description: Port for agent to connect to blobstore server used by 'dav' blobstore plugin
-  blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by 'dav' blobstore plugin
-  blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by 'dav' blobstore plugin
-  blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|local|s3)
-  blobstore.path:
-    description: local blobstore path
-  blobstore.bucket_name:
-    description: S3 Bucket used by s3 blobstore plugin
-  blobstore.access_key_id:
-    description: AWS access_key_id used by s3 blobstore plugin
-  blobstore.secret_access_key:
-    description: AWS secret_access_key used by s3 blobstore plugin
-  blobstore.host:
-    description: Host of blobstore server used by s3 blobstore plugin
-  blobstore.s3_region:
-    description: AWS region used by s3 blobstore plugin
-  blobstore.s3_port:
-    description: Port of blobstore server used by s3 blobstore plugin
-    default: 443
-  blobstore.use_ssl:
-    description: Whether the s3 blobstore plugin should use SSL to connect to the blobstore server
-    default: true
-  blobstore.ssl_verify_peer:
-    description: Whether the s3 blobstore plugin should verify its peer when using SSL
-    default: true
-  blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
 
   nats.user:
     description: NATS username used by agent to subscribe to agent requests

--- a/jobs/openstack_cpi/spec
+++ b/jobs/openstack_cpi/spec
@@ -108,61 +108,9 @@ properties:
     description: List of NTP servers
     example: ["0.us.pool.ntp.org", "1.us.pool.ntp.org"]
 
-  agent.blobstore.access_key_id:
-    description: access_key_id for agent used by s3 blobstore plugin
-  agent.blobstore.secret_access_key:
-    description: secret_access_key for agent used by s3 blobstore plugin
   agent.mbus:
     description: Message bus endpoint for the agent to start accepting agent requests
     example: https://user:password@192.168.0.1:5000
-  agent.blobstore.address:
-    description: Address for agent to connect to blobstore server used by 'dav' blobstore plugin
-  agent.blobstore.use_ssl:
-    description: Whether the agent blobstore plugin should use SSL to connect to the blobstore server
-  agent.blobstore.s3_region:
-    description: AWS region for agent used by s3 blobstore plugin
-  agent.blobstore.s3_port:
-    description: Port of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.host:
-    description: Host of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.ssl_verify_peer:
-    description: Whether the agent blobstore plugin should verify its peer when using SSL
-  agent.blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-
-  blobstore.address:
-    description: Address for agent to connect to blobstore server used by 'dav' blobstore plugin
-  blobstore.port:
-    description: Port for agent to connect to blobstore server used by 'dav' blobstore plugin
-  blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by 'dav' blobstore plugin (Optional)
-  blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by 'dav' blobstore plugin (Required only when user is provided)
-  blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|local|s3)
-  blobstore.path:
-    description: local blobstore path
-  blobstore.bucket_name:
-    description: S3 Bucket used by s3 blobstore plugin
-  blobstore.access_key_id:
-    description: AWS access_key_id used by s3 blobstore plugin
-  blobstore.secret_access_key:
-    description: AWS secret_access_key used by s3 blobstore plugin
-  blobstore.host:
-    description: Host of blobstore server used by s3 blobstore plugin
-  blobstore.s3_region:
-    description: AWS region used by s3 blobstore plugin
-  blobstore.s3_port:
-    description: Port of blobstore server used by s3 blobstore plugin
-    default: 443
-  blobstore.use_ssl:
-    description: Whether the s3 blobstore plugin should use SSL to connect to the blobstore server
-    default: true
-  blobstore.ssl_verify_peer:
-    description: Whether the s3 blobstore plugin should verify its peer when using SSL
-    default: true
-  blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
 
   nats.user:
     description: NATS username used by agent to subscribe to agent requests

--- a/jobs/openstack_cpi/templates/cpi.json.erb
+++ b/jobs/openstack_cpi/templates/cpi.json.erb
@@ -64,51 +64,6 @@
     end
   end
 
-  if_p('blobstore.provider') do |provider|
-    blobstore_params = {
-      'provider' => provider
-    }
-
-    if provider == 's3'
-      options_params = {
-        'bucket_name' => p('blobstore.bucket_name'),
-        'access_key_id' => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']),
-        'secret_access_key' => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'])
-      }
-
-      def update_blobstore_options(options, manifest_key, rendered_key=manifest_key)
-        value = p(["agent.blobstore.#{manifest_key}", "blobstore.#{manifest_key}"], nil)
-        options[rendered_key] = value unless value.nil?
-      end
-
-      update_blobstore_options(options_params, 'use_ssl')
-      update_blobstore_options(options_params, 's3_port', 'port')
-      update_blobstore_options(options_params, 'host')
-      update_blobstore_options(options_params, 'ssl_verify_peer')
-      update_blobstore_options(options_params, 's3_signature_version', 'signature_version')
-      update_blobstore_options(options_params, 's3_region', 'region')
-
-    elsif provider == 'local'
-      options_params = {
-        'blobstore_path' => p('blobstore.path')
-      }
-    else
-      options_params = {
-        'endpoint' => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
-      }
-
-      if_p('blobstore.agent.user') do
-        options_params['user'] = p('blobstore.agent.user')
-        options_params['password'] = p('blobstore.agent.password')
-      end
-    end
-
-    blobstore_params['options'] = options_params
-
-    params['cloud']['properties']['agent'] ||= {}
-    params['cloud']['properties']['agent']['blobstore'] = blobstore_params
-  end
-
   if_p('agent.mbus') do |mbus|
     params['cloud']['properties']['agent'] ||= {}
     params['cloud']['properties']['agent']['mbus'] = mbus

--- a/src/bosh_openstack_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -25,10 +25,6 @@ describe 'cpi.json.erb' do
         'ignore_server_availability_zone' => 'openstack.ignore_server_availability_zone',
       },
       'ntp' => [],
-      'blobstore' => {
-        'provider' => 'local',
-        'path' => 'blobstore-local-path',
-      },
       'registry' => {
         'username' => 'registry.username',
         'password' => 'registry.password',
@@ -87,17 +83,6 @@ describe 'cpi.json.erb' do
     )
   end
 
-  context 'when blobstore is configured for v2' do
-    it 'template rendering succeeds' do
-      manifest_cpi_v2['blobstore'] = {
-        'provider' => 'local',
-        'path' => 'blobstore-local-path',
-      }
-
-      expect(cpi_v2_json['cloud']['properties']['agent']['blobstore']['provider']).to eq('local')
-    end
-  end
-
   context 'when using human readable VM names' do
     it 'template rendering succeeds' do
       manifest_cpi_v2['openstack']['human_readable_vm_names'] = true
@@ -149,20 +134,12 @@ describe 'cpi.json.erb' do
   end
 
   context 'when cpi api v1' do
-    let(:rendered_blobstore) { cpi_v1_json['cloud']['properties']['agent']['blobstore'] }
-
     it 'is able to render the erb given most basic manifest properties' do
       expect(cpi_v1_json).to eq(
         'cloud' => {
           'plugin' => 'openstack',
           'properties' => {
             'agent' => {
-              'blobstore' => {
-                'options' => {
-                  'blobstore_path' => 'blobstore-local-path',
-                },
-                'provider' => 'local',
-              },
               'mbus' => 'nats://nats-user:nats-password@nats_address.example.com:4222',
               'ntp' => [],
             },
@@ -190,142 +167,9 @@ describe 'cpi.json.erb' do
               'password' => 'registry.password',
               'user' => 'registry.username',
             },
-          },
-        },
-      )
-    end
-
-    context 'when using an s3 blobstore' do
-      context 'when provided a minimal configuration' do
-        before do
-          manifest_cpi_v1['blobstore'].merge!(
-            'provider' => 's3',
-            'bucket_name' => 'my_bucket',
-            'access_key_id' => 'blobstore-access-key-id',
-            'secret_access_key' => 'blobstore-secret-access-key',
-          )
-        end
-
-        it 'renders the s3 provider section with the correct defaults' do
-          expect(rendered_blobstore).to eq(
-            'provider' => 's3',
-            'options' => {
-              'bucket_name' => 'my_bucket',
-              'access_key_id' => 'blobstore-access-key-id',
-              'secret_access_key' => 'blobstore-secret-access-key',
-              'use_ssl' => true,
-              'ssl_verify_peer' => true,
-              'port' => 443,
-            },
-          )
-        end
-      end
-
-      context 'when provided a maximal configuration' do
-        before do
-          manifest_cpi_v1['blobstore'].merge!(
-            'provider' => 's3',
-            'bucket_name' => 'my_bucket',
-            'access_key_id' => 'blobstore-access-key-id',
-            'secret_access_key' => 'blobstore-secret-access-key',
-            's3_region' => 'blobstore-region',
-            'use_ssl' => false,
-            's3_port' => 21,
-            'host' => 'blobstore-host',
-            'ssl_verify_peer' => true,
-            's3_signature_version' => '11',
-          )
-        end
-
-        it 'renders the s3 provider section correctly' do
-          expect(rendered_blobstore).to eq(
-            'provider' => 's3',
-            'options' => {
-              'bucket_name' => 'my_bucket',
-              'access_key_id' => 'blobstore-access-key-id',
-              'secret_access_key' => 'blobstore-secret-access-key',
-              'region' => 'blobstore-region',
-              'use_ssl' => false,
-              'host' => 'blobstore-host',
-              'port' => 21,
-              'ssl_verify_peer' => true,
-              'signature_version' => '11',
-            },
-          )
-        end
-
-        it 'prefers the agent properties when they are both included' do
-          manifest_cpi_v1['agent'] = {
-            'blobstore' => {
-              'access_key_id' => 'agent_access_key_id',
-              'secret_access_key' => 'agent_secret_access_key',
-              's3_region' => 'agent-region',
-              'use_ssl' => true,
-              's3_port' => 42,
-              'host' => 'agent-host',
-              'ssl_verify_peer' => true,
-              's3_signature_version' => '99',
-            },
-          }
-
-          manifest_cpi_v1['blobstore'].merge!(
-            'access_key_id' => 'blobstore_access_key_id',
-            'secret_access_key' => 'blobstore_secret_access_key',
-            's3_region' => 'blobstore-region',
-            'use_ssl' => false,
-            's3_port' => 21,
-            'host' => 'blobstore-host',
-            'ssl_verify_peer' => false,
-            's3_signature_version' => '11',
-          )
-
-          expect(rendered_blobstore['options']['access_key_id']).to eq('agent_access_key_id')
-          expect(rendered_blobstore['options']['secret_access_key']).to eq('agent_secret_access_key')
-          expect(rendered_blobstore['options']['region']).to eq('agent-region')
-          expect(rendered_blobstore['options']['use_ssl']).to be true
-          expect(rendered_blobstore['options']['port']).to eq(42)
-          expect(rendered_blobstore['options']['host']).to eq('agent-host')
-          expect(rendered_blobstore['options']['ssl_verify_peer']).to be true
-          expect(rendered_blobstore['options']['signature_version']).to eq('99')
-        end
-      end
-    end
-
-    context 'when using a dav blobstore' do
-      before do
-        manifest_cpi_v1['blobstore'] = {
-          'provider' => 'dav',
-          'address' => 'blobstore-address.example.com',
-          'port' => '25250',
-          'agent' => {
-            'user' => 'agent',
-            'password' => 'agent-password'
           }
         }
-      end
-
-      it 'renders the agent blobstore section with the correct values' do
-        expect(rendered_blobstore).to eq(
-          'provider' => 'dav',
-          'options' => {
-            'endpoint' => 'http://blobstore-address.example.com:25250',
-            'user' => 'agent',
-            'password' => 'agent-password'
-          }
-        )
-      end
-
-      context 'when enabling signed URLs' do
-        before do
-          manifest_cpi_v1['blobstore']['agent'].delete('user')
-          manifest_cpi_v1['blobstore']['agent'].delete('password')
-        end
-
-        it 'does not render agent user/password for accessing blobstore' do
-          expect(rendered_blobstore['options']['user']).to be_nil
-          expect(rendered_blobstore['options']['password']).to be_nil
-        end
-      end
+      )
     end
   end
 end


### PR DESCRIPTION
The BOSH agent reads its blobstore settings from the metadata API endpoint (or equivalent) for its VM within the IaaS. If the blobstore settings are not set in the `env.bosh.blobstores` property, it will fallback to the top-level `blobstore` property in the metadata.

However, in modern configurations, the Director always sends the blobstore settings as part of the environment hash. Additionally, the Director does redaction of credentials in the environment hash when the signed URLs blobstore feature is enabled. This redaction is not applied to the top-level `blobstore` property in the metadata because that is generated solely by the CPI.

Rather than updating each CPI to know about the signed URL feature, we are instead removing the `blobstore` properties from the CPI. This will ensure that Director is the sole point of contact when configuring agent blobstore settings, and ensure that they are always properly redacted.