### PR TITLE
Remove PowerDNS references

### DIFF
--- a/ci/tasks/deploy-dynamic-networking.sh
+++ b/ci/tasks/deploy-dynamic-networking.sh
@@ -64,7 +64,6 @@ OPS_FILES=()
 OPTIONAL_VARIABLES=()
 
 OPS_FILES+=( "--ops-file=../bosh-deployment/jumpbox-user.yml" )
-OPS_FILES+=( "--ops-file=../bosh-deployment/misc/powerdns.yml" )
 OPS_FILES+=( "--ops-file=../bosh-deployment/openstack/cpi.yml" )
 OPS_FILES+=( "--ops-file=../bosh-deployment/external-ip-not-recommended.yml" )
 OPS_FILES+=( "--ops-file=../bosh-deployment/misc/source-releases/bosh.yml" )

--- a/ci/tasks/deploy-manual-networking.sh
+++ b/ci/tasks/deploy-manual-networking.sh
@@ -71,7 +71,6 @@ echo "check bosh deployment interpolation"
 bosh-go int ../bosh-deployment/bosh.yml \
     --var-errs --var-errs-unused \
     --vars-store ./credentials.yml \
-    -o ../bosh-deployment/misc/powerdns.yml \
     -o ../bosh-deployment/openstack/cpi.yml \
     ${maybe_use_custom_ca_ops_file} \
     -o ../bosh-deployment/external-ip-not-recommended.yml \


### PR DESCRIPTION
This component is being removed from BOSH itself.

See https://github.com/cloudfoundry/bosh/pull/2501