### PR TITLE
Adding multiqueue support for Virtio to the stemcell

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/stemcell_creator.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/stemcell_creator.rb
@@ -119,8 +119,8 @@ module Bosh::OpenStackCloud
       image_properties = {}
       image_options = %w[version os_type os_distro architecture auto_disk_config
                          hw_vif_model hw_disk_bus_model hw_scsi_model hw_disk_bus
-                         hypervisor_type vmware_adaptertype vmware_disktype
-                         vmware_linked_clone vmware_ostype]
+                         hw_vif_multiqueue_enabled hypervisor_type vmware_adaptertype 
+                         vmware_disktype vmware_linked_clone vmware_ostype]
       image_options.reject { |image_option| properties[property_option_for_image_option(image_option)].nil? }.each do |image_option|
         image_properties[image_option.to_sym] = properties[property_option_for_image_option(image_option)].to_s
       end

--- a/src/bosh_openstack_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/stemcell_creator_spec.rb
@@ -32,6 +32,16 @@ describe Bosh::OpenStackCloud::HeavyStemcellCreator do
       )
     end
 
+    it 'supports virtio multiqueue network' do
+      properties = {
+        'hw_vif_multiqueue_enabled' => true,
+      }
+
+      expect(subject.normalize_image_properties(properties)).to include(
+        :hw_vif_multiqueue_enabled,
+      )
+    end
+
     it 'maps hypervisor key to hypervisor_type' do
       properties = {
         'hypervisor' => 'kvm',


### PR DESCRIPTION
Hello,

based on the last pull request from: https://github.com/cloudfoundry/bosh-openstack-cpi-release/pull/280, 
I have added the property hw_vif_multiqueue_enabled, to enable the multiqueue feature to the network based on virtio, with this will complement the full virtio support.

For any questions or requirements, please let me know.

Thanks

David