### PR TITLE
Enhance Github Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Run Go Tests
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
@@ -9,6 +9,9 @@ on:
   pull_request:
     paths:
       - 'src/openstack_cpi_golang/**'
+  push:
+    branches:
+      - master
 
 jobs:
   go:
@@ -27,23 +30,23 @@ jobs:
         with:
           go-version-file: src/openstack_cpi_golang/go.mod
 
-      - name: Install golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
-      - name: Run golangci-lint and tests on Windows
-        if: ${{ matrix.os == 'windows-2019' }}
-        run: |
-          cd src/openstack_cpi_golang
-          golangci-lint run
-          go test ./cpi/...
-          go test ./integration/...
-
-      - name: Run golangci-lint and tests on non-Windows
+      - name: Run golangci-lint
         if: ${{ matrix.os != 'windows-2019' }}
-        run: |
-          cd src/openstack_cpi_golang
-          golangci-lint run --enable goimports
-          go test ./cpi/...
-          go test ./integration/...
-        shell: bash
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: src/openstack_cpi_golang
+
+      - name: Run golangci-lint
+        if: ${{ matrix.os == 'windows-2019' }}
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: src/openstack_cpi_golang
+          args: --disable=goimports
+
+      - name: Run unit tests
+        run: scripts/run-unit-tests
+        working-directory: src/openstack_cpi_golang
+
+      - name: Run integration tests
+        run: scripts/run-integration-tests
+        working-directory: src/openstack_cpi_golang

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,17 @@
-name: Run Specs
-on: [ push, pull_request ]
+name: Run Ruby Specs
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src/bosh_openstack_cpi/**'
+  push:
+    branches:
+      - master
 
 jobs:
   unit_specs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+# https://golangci-lint.run/usage/configuration/
+run:
+  timeout: 3m # 1m default times out on github-action runners
+
+output:
+  # Sort results by: filepath, line and column.
+  sort-results: true


### PR DESCRIPTION
This PR incorporate feedback from https://github.com/cloudfoundry/bosh-openstack-cpi-release/pull/290#issuecomment-2436147678 

In addition to some details:

- add dependabot.yml to find any outdated GitHub Actions
- add .golangci.yml increasing the timeout to 3m for the windows-runners
-  For the go work flow: replace shell steps with separate unit and integration tests
- Make the ruby and go workflows run only when changes are made into the corresponding source folders
- Enable workflow_dispatch to allow manual triggering of the workflow actions
- Enable on-push workflows only on the master branch to avoid multiple redundant runs on a pull request