### PR TITLE
Fixes teardown-director task

### DIFF
--- a/ci/tasks/teardown-director.yml
+++ b/ci/tasks/teardown-director.yml
@@ -9,7 +9,6 @@ inputs:
   - name: bosh-director-deployment
   - name: stemcell
   - name: bosh-release
-  - name: version-semver
   - name: terraform-cpi
 run:
   path: bosh-openstack-cpi-release/ci/tasks/teardown-director.sh


### PR DESCRIPTION
The version-semver resource is no longer supplied, and isn't used by the script that this task runs, so we need to remove the resource.