### PR TITLE
Increases timeouts

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,7 +1,7 @@
 ---
 custom:
   timeouts:
-    long: &timeouts-long 2h
+    long: &timeouts-long 3h
   debug_bats: &debug_bats true
 
 jobs:


### PR DESCRIPTION
With the move of the Openstack cluster to a new datacenter, it looks like two hours is sometimes just barely not enough time for the tests to complete. This commit increases the task timeout to three hours.