### PR TITLE
Set git private key for CVE check

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -249,6 +249,7 @@ jobs:
         input_mapping:
           input_repo: bosh-openstack-cpi-release
         params:
+          GIT_PRIVATE_KEY: ((github_deploy_key_bosh-openstack-cpi-release.private_key))
           SEVERITY: CRITICAL,HIGH
         on_success:
           do:


### PR DESCRIPTION
This repo uses gitlfs, so we need to pass the private key to the CVE check task in order to compare current with previous version.