### PR TITLE
Attempt to pin back Terraform to 2.1.x

### DIFF
--- a/ci/terraform/ci/lifecycle/versions.tf
+++ b/ci/terraform/ci/lifecycle/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "terraform-provider-openstack/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 2.1.0, < 3.0.0"
 }

--- a/ci/terraform/ci/modules/lifecycle/versions.tf
+++ b/ci/terraform/ci/modules/lifecycle/versions.tf
@@ -4,5 +4,5 @@ terraform {
       source = "terraform-provider-openstack/openstack"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 2.1.0, < 3.0.0"
 }


### PR DESCRIPTION
When running terraform destroy with the 3.0.x version line, we are seeing terraform only destroying key pair resources, and not other things like network, security group, etc.