### PR TITLE
Makes Terraform resource work correctly

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -56,10 +56,10 @@ jobs:
     tags: [ "nimbus" ]
     timeout: *timeouts-long
     params:
-      env_name: lifecycle
+      env_name: "lifecycle-openstack-tests"
       terraform_source: bosh-openstack-cpi-release/ci/terraform/ci/lifecycle
       vars: &lifecycle-terraform-vars
-        prefix: lifecycle
+        prefix: "lifecycle-openstack-tests"
         auth_url: ((concourse_openstack_auth.auth_url))
         cacert_file: ((config-json.tf_ca_file_path))
         user_name: ((config-json.openstack_username))
@@ -102,7 +102,7 @@ jobs:
       tags: [ "nimbus" ]
       params:
         action: destroy
-        env_name: lifecycle
+        env_name: "lifecycle-openstack-tests"
         terraform_source: bosh-openstack-cpi-release/ci/terraform/ci/lifecycle
         vars: *lifecycle-terraform-vars
       get_params:


### PR DESCRIPTION
This commit
1) Makes the initial Terraform Apply 'put' to the terraform resource not
   explode because the tfstate file doesn't exist.
2) MAYBE resolves the "Workspace not empty" problem on the Terraform
   Destroy 'put' to the Terraform resource.

NOTE:
I have no idea why this change resolves #1. I don't know if 'lifecycle' is a reserved word somewhere in the guts of Terraform, if the GCS storage adapter fails when env names and/or prefixes are too short, or if there must be hyphens in an env name and/or prefix. All I DO know is that I've had two runs in a row where the resource correctly started from a bucket that didn't have the tfstate file it was looking for and created all the resources it was instructed to.

I also do not know if this actually resolves #2, or if I've just gotten lucky with the last two runs. Only time will tell.