### PR TITLE
Switch from terraform resource for lifecycle job, as well as switching to the "openstack" tag for many resources and tasks

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,6 +49,7 @@ jobs:
   - task: write_ca_file
     tags: [ "openstack" ]
     file: bosh-openstack-cpi-release/ci/tasks/write-ca-file.yml
+    image: openstack-cpi-release-docker-image
     params:
       file_content: ((concourse_openstack_auth.openstack_ca_cert))
 
@@ -77,6 +78,7 @@ jobs:
       tags: [ "openstack" ]
       timeout: *timeouts-long
       file: bosh-openstack-cpi-release/ci/tasks/run-lifecycle.yml
+      image: openstack-cpi-release-docker-image
       params:
         BOSH_OPENSTACK_DOMAIN: ((config-json.lifecycle_openstack_domain))
         BOSH_OPENSTACK_PROJECT: ((config-json.openstack_project))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,13 +47,13 @@ jobs:
       timeout: *timeouts-long
 
   - task: write_ca_file
-    tags: [ "nimbus" ]
+    tags: [ "openstack" ]
     file: bosh-openstack-cpi-release/ci/tasks/write-ca-file.yml
     params:
       file_content: ((concourse_openstack_auth.openstack_ca_cert))
 
   - put: terraform-cpi
-    tags: [ "nimbus" ]
+    tags: [ "openstack" ]
     timeout: *timeouts-long
     params:
       env_name: "lifecycle-openstack-tests"
@@ -74,7 +74,7 @@ jobs:
         use_lbaas: false
   - do:
     - task: test
-      tags: [ "nimbus" ]
+      tags: [ "openstack" ]
       timeout: *timeouts-long
       file: bosh-openstack-cpi-release/ci/tasks/run-lifecycle.yml
       params:
@@ -94,12 +94,12 @@ jobs:
         BOSH_OPENSTACK_AVAILABILITY_ZONE: ((config-json.availability_zone))
         BOSH_OPENSTACK_EXCLUDE_CINDER_V1: true
     - put: lifecycle-log
-      tags: [ "nimbus" ]
+      tags: [ "openstack" ]
       timeout: *timeouts-long
       params: { file: output/lifecycle.log }
     ensure:
       put: terraform-cpi
-      tags: [ "nimbus" ]
+      tags: [ "openstack" ]
       params:
         action: destroy
         env_name: "lifecycle-openstack-tests"
@@ -121,7 +121,7 @@ jobs:
     - { trigger: false,                    get: bosh-deployment, timeout: *timeouts-long }
 
   - put: terraform-cpi
-    tags: [ "nimbus" ]
+    tags: [ "openstack" ]
     timeout: *timeouts-long
     params:
       env_name: bats-ubuntu-manual
@@ -152,7 +152,7 @@ jobs:
 
   - do:
     - task: deploy
-      tags: [ "nimbus" ]
+      tags: [ "openstack" ]
       timeout: *timeouts-long
       file: bosh-openstack-cpi-release/ci/tasks/deploy-manual-networking.yml
       params:
@@ -172,7 +172,7 @@ jobs:
         DEBUG_BATS: *debug_bats
 
     - task: test
-      tags: [ "nimbus" ]
+      tags: [ "openstack" ]
       timeout: *timeouts-long
       file: bosh-openstack-cpi-release/ci/tasks/run-manual-networking-bats.yml
       params:
@@ -184,18 +184,18 @@ jobs:
         bats_rspec_tags: "--tag ~ssh"
       ensure:
         task: print-task-errors
-        tags: [ "nimbus" ]
+        tags: [ "openstack" ]
         timeout: *timeouts-long
         file: bosh-openstack-cpi-release/ci/tasks/print_task_errors.yml
     ensure:
       do:
       - task: teardown-director
-        tags: [ "nimbus" ]
+        tags: [ "openstack" ]
         timeout: *timeouts-long
         file: bosh-openstack-cpi-release/ci/tasks/teardown-director.yml
         ensure:
           put: terraform-cpi
-          tags: [ "nimbus" ]
+          tags: [ "openstack" ]
           params:
             action: destroy
             env_name: bats-ubuntu-manual
@@ -303,7 +303,7 @@ jobs:
       trigger: true
     - get: release-notes
   - task: promote
-    tags: [ "nimbus" ]
+    tags: [ "openstack" ]
     timeout: *timeouts-long
     file: bosh-shared-ci/tasks/release/create-final-release.yml
     input_mapping:
@@ -454,7 +454,7 @@ resources:
 
 - name: terraform-cpi
   type: terraform
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     backend_type: gcs
     backend_config:
@@ -469,7 +469,7 @@ resources:
 
 - name: lifecycle-log
   type: gcs
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     bucket: bosh-openstack-cpi-blobs
     versioned_file: lifecycle.log
@@ -484,7 +484,7 @@ resources:
 
 - name: bosh-openstack-cpi-release
   type: git
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     uri: git@github.com:cloudfoundry/bosh-openstack-cpi-release.git
     branch: master
@@ -509,26 +509,26 @@ resources:
 
 - name: bats
   type: git
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     uri: https://github.com/cloudfoundry/bosh-acceptance-tests.git
     branch: master
 
 - name: bosh-release
   type: bosh-io-release
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     repository: cloudfoundry/bosh
 
 - name: openstack-ubuntu-jammy-stemcell
   type: bosh-io-stemcell
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     name: bosh-openstack-kvm-ubuntu-jammy-go_agent
 
 - name: bosh-deployment
   type: git
-  tags: [ "nimbus" ]
+  tags: [ "openstack" ]
   source:
     uri: https://github.com/cloudfoundry/bosh-deployment.git
     branch: master

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -53,26 +53,26 @@ jobs:
     params:
       file_content: ((concourse_openstack_auth.openstack_ca_cert))
 
-  - put: terraform-cpi
+  - task: terraform-apply
     tags: [ "openstack" ]
     timeout: *timeouts-long
-    params:
-      env_name: "lifecycle-openstack-tests"
-      terraform_source: bosh-openstack-cpi-release/ci/terraform/ci/lifecycle
-      vars: &lifecycle-terraform-vars
-        prefix: "lifecycle-openstack-tests"
-        auth_url: ((concourse_openstack_auth.auth_url))
-        cacert_file: ((config-json.tf_ca_file_path))
-        user_name: ((config-json.openstack_username))
-        password: ((config-json.openstack_password))
-        domain_name: ((config-json.lifecycle_openstack_domain))
-        project_name: ((config-json.openstack_project))
-        ext_net_id: ((config-json.tf_external_network_id))
-        ext_net_name: ((config-json.tf_external_network_name))
-        region_name: ((config-json.tf_region_name))
-        openstack_default_key_public_key: ((config-json.tf_default_public_key))
-        dns_nameservers: ((config-json.tf_dns_nameservers))
-        use_lbaas: false
+    image: terraform-image
+    file: "bosh-openstack-cpi-release/ci/tasks/terraform-apply-lifecycle.yml"
+    params: &lifecycle-terraform-params
+      TF_VAR_prefix: "lifecycle-openstack-tests"
+      TF_VAR_auth_url: ((concourse_openstack_auth.auth_url))
+      TF_VAR_cacert_file: ((config-json.tf_ca_file_path))
+      TF_VAR_user_name: ((config-json.openstack_username))
+      TF_VAR_password: ((config-json.openstack_password))
+      TF_VAR_domain_name: ((config-json.lifecycle_openstack_domain))
+      TF_VAR_project_name: ((config-json.openstack_project))
+      TF_VAR_ext_net_id: ((config-json.tf_external_network_id))
+      TF_VAR_ext_net_name: ((config-json.tf_external_network_name))
+      TF_VAR_region_name: ((config-json.tf_region_name))
+      TF_VAR_openstack_default_key_public_key: ((config-json.tf_default_public_key))
+      TF_VAR_dns_nameservers: ((config-json.tf_dns_nameservers))
+      TF_VAR_use_lbaas: false
+
   - do:
     - task: test
       tags: [ "openstack" ]
@@ -100,15 +100,12 @@ jobs:
       timeout: *timeouts-long
       params: { file: output/lifecycle.log }
     ensure:
-      put: terraform-cpi
+      task: terraform-destroy
       tags: [ "openstack" ]
-      params:
-        action: destroy
-        env_name: "lifecycle-openstack-tests"
-        terraform_source: bosh-openstack-cpi-release/ci/terraform/ci/lifecycle
-        vars: *lifecycle-terraform-vars
-      get_params:
-        action: destroy
+      timeout: *timeouts-long
+      image: terraform-image
+      file: "bosh-openstack-cpi-release/ci/tasks/terraform-destroy-lifecycle.yml"
+      params: *lifecycle-terraform-params
 
 - name: bats-ubuntu-manual
   serial: true
@@ -421,7 +418,7 @@ resource_types:
 - name: terraform
   type: registry-image
   check_every: 168h
-  source:
+  source: &terraform-resource-source-keys
     repository: ljfranklin/terraform-resource
     username: ((docker.username))
     password: ((docker.password))
@@ -537,6 +534,7 @@ resources:
 
 - name: openstack-cpi-release-docker-image
   type: docker-image
+  tags: [ "openstack" ]
   check_every: never
   source:
     username: ((docker.username))
@@ -579,3 +577,8 @@ resources:
     start: 3:00 -0700
     stop: 4:30 -0700
     days: [ Saturday ]
+
+- name: terraform-image
+  type: registry-image
+  check_every: 168h
+  source: *terraform-resource-source-keys

--- a/ci/tasks/terraform-apply-lifecycle.sh
+++ b/ci/tasks/terraform-apply-lifecycle.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+BASE_DIR=`pwd`
+
+pushd bosh-openstack-cpi-release/ci/terraform/ci/lifecycle
+  terraform init
+  terraform apply -auto-approve -input=false
+  cp -r ${BASE_DIR}/bosh-openstack-cpi-release/ci ${BASE_DIR}/terraform-cpi
+  # Write out the 'terraform output' data as JSON, as the terraform-resource would:
+  (echo "{"; terraform output | sed -e 's/\(.*\) =/"\1": /' -e '$ ! s/$/,/'; echo "}") > ${BASE_DIR}/terraform-cpi/metadata
+popd
+
+echo ""
+echo "******************************"
+echo "Metadata JSON passed to subsequent tests:"
+cat terraform-cpi/metadata
+echo "******************************"

--- a/ci/tasks/terraform-apply-lifecycle.yml
+++ b/ci/tasks/terraform-apply-lifecycle.yml
@@ -1,0 +1,7 @@
+---
+platform: linux
+
+inputs: [ { name: bosh-openstack-cpi-release } ]
+outputs: [ {name: terraform-cpi } ]
+run:
+  path: 'ci/tasks/terraform-apply-lifecycle.sh'

--- a/ci/tasks/terraform-destroy-lifecycle.sh
+++ b/ci/tasks/terraform-destroy-lifecycle.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "******************************"
+echo "Metadata JSON passed to our destroy:"
+cat terraform-cpi/metadata
+echo "******************************"
+echo ""
+
+cd terraform-cpi/ci/terraform/ci/lifecycle
+terraform destroy -auto-approve -input=false

--- a/ci/tasks/terraform-destroy-lifecycle.yml
+++ b/ci/tasks/terraform-destroy-lifecycle.yml
@@ -1,0 +1,6 @@
+---
+platform: linux
+
+inputs: [ {name: terraform-cpi } ]
+run:
+  path: 'ci/tasks/terraform-destroy-lifecycle.sh'


### PR DESCRIPTION
This PR does the following big things:

1) Switches away from the "nimbus" tag to the "openstack" tag for all tagged Tasks and Resources. We're doing this because the Nimbus workers are pretty unreliable, and also because we have multiple 'nimbus' workers, but a _single_ 'openstack' worker which massively reduces the time spent waiting for volume transfers.
2) Updates the 'lifecycle' Job to stop using the Concourse Terraform Resource and start using a pair of simple scripts to drive Terraform. For details about why this change is being made, please read the commit message whose headline is 'Switches away from Terraform Resource to script'.

One should also note that this is a total replacement of PR #304. That PR only appeared to make things work reliably. They did not actually work reliably.