### PR TITLE
Handle 'tolist' Terraform construction

### DIFF
--- a/ci/tasks/convert-terraform-output-to-mostly-json.awk
+++ b/ci/tasks/convert-terraform-output-to-mostly-json.awk
@@ -1,0 +1,33 @@
+# NOTE: This 'awk' program was written to work with BusyBox awk. It might work differently with GAWK.
+#       It was written by someone who is very bad at 'awk'.
+#
+# This 'awk' program exists to do most of the changing of 'terraform output' output to JSON. It wraps
+# keys in double-quotes, changes " = " to ": ", appends "," to each line, and also converts input of the form
+# key = tolist([
+#  "var 1",
+#  "var 2",
+#  "var N",
+#])'
+# to
+# "key": [ "var 1", "var 2", "var N" ],
+#
+# It is to be used with a program that removes the trailing "," from its last line of output, and then wraps the output in "{ }"
+
+BEGIN { in_tolist = 0; acc = ""; key = ""}
+
+# start of tolist list
+/ = tolist\(\[/ {
+  in_tolist = 1
+  key = $1
+  next
+}
+# end of tolist list
+/^\]\)$/ { 
+  in_tolist = 0
+  gsub(/ /, ", ", acc)
+  print "\"" key "\": [" acc "]," ; acc = ""
+  next
+}
+in_tolist == 1 && acc == "" { gsub(/,/, "", $1); acc = $1; next }
+in_tolist == 1 { gsub(/,/, "", $1); acc = acc " " $1; next }
+in_tolist == 0 { pvs = FS; FS = "="; print "\"" $1 "\": " $3 ","; FS = pvs }

--- a/ci/tasks/terraform-apply-bats-manual.sh
+++ b/ci/tasks/terraform-apply-bats-manual.sh
@@ -8,8 +8,16 @@ pushd bosh-openstack-cpi-release/ci/terraform/ci/bats-manual
   terraform init
   terraform apply -auto-approve -input=false
   cp -r ${BASE_DIR}/bosh-openstack-cpi-release/ci ${BASE_DIR}/terraform-cpi
-  # Write out the 'terraform output' data as JSON, as the terraform-resource would:
-  (echo "{"; terraform output | sed -e 's/\(.*\) =/"\1": /' -e '$ ! s/$/,/'; echo "}") > ${BASE_DIR}/terraform-cpi/metadata
+
+  # This subshell converts 'terraform output' output into JSON to be consumed by former clients of the Terraform Resource.
+  # The only special Terraform construction its awk program handles is 'tolist'. The 'sed' program at the end is to remove
+  # the "," from the last line of the awk output, because I don't know how to make 'awk' do something different on the LAST
+  # line of the input.
+  (
+    echo "{"
+    terraform output | awk -f ${BASE_DIR}/bosh-openstack-cpi-release/ci/tasks/convert-terraform-output-to-mostly-json.awk | sed -e '$ s/,$//'
+    echo "}"
+  ) > ${BASE_DIR}/terraform-cpi/metadata
 popd
 
 echo ""


### PR DESCRIPTION
This commit should correctly handle the 'tolist' construction in the output from the 'terraform output' command. That construction is a bit too complex for my 'sed' skills, so I've fallen back on my crummy 'awk' skills to provide a replacement to the inline 'sed'.

I am bad at 'awk', so the 'awk' program definitely could be improved, but it's fit for its current limited purpose.