### PR TITLE
prevent re-fetching of vendored go packages due to them being incompletely packaged

### DIFF
--- a/packages/openstack_cpi_golang/spec
+++ b/packages/openstack_cpi_golang/spec
@@ -5,6 +5,4 @@ dependencies:
 - golang-1-linux
 
 files:
-- "openstack_cpi_golang/**/*.go"
-- "openstack_cpi_golang/go.{mod,sum}"
-- "openstack_cpi_golang/vendor/modules.txt"
+- "openstack_cpi_golang/**/*"


### PR DESCRIPTION
We noticed that we incompletely package the vendored go packages, in contrast to how it is done in [bosh-google-cpi-release](https://github.com/cloudfoundry/bosh-google-cpi-release/blob/master/packages/bosh-google-cpi/spec) for example. This forced the runtime processes to re-download the vendored packages, which is not expected. This PR fixes this behaviour.