### PR TITLE
Remove redundant require 'set' for Ruby 3.3 compatibility

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack.rb
@@ -5,7 +5,6 @@ end
 require 'fog/openstack'
 require 'httpclient'
 require 'json'
-require 'set'
 require 'tmpdir'
 require 'securerandom'
 require 'membrane'


### PR DESCRIPTION
## Summary

- Remove `require 'set'` from `lib/cloud/openstack.rb` — `Set` is part of Ruby core since 3.2, and RuboCop 1.78 (`Lint/RedundantRequireStatement`) now flags it as an offense under Ruby 3.3.

## Why

The `bump-bosh-packages` CI job vendors `openstack-ruby-3.3` and then runs unit specs. With Ruby 3.3 the bundled RuboCop treats `require 'set'` as redundant and fails the build. This is a one-line fix to unblock that job.

## Test plan

- [x] `run-unit-specs` passes on CI after merge