### PR TITLE
ci: gate devstack readiness on final setup step

### DIFF
--- a/ci/tasks/wait-for-devstack.sh
+++ b/ci/tasks/wait-for-devstack.sh
@@ -25,8 +25,12 @@ for i in $(seq 1 100); do
   fi
 done
 
-echo "waiting for CI user auth (confirms create_project_and_user has run) ..."
-for i in $(seq 1 20); do
+# CI-user auth is the final setup action on the VM (see install-devstack.sh create_user_and_roles),
+# so a 201 here means flavors, project, and quotas are all in place — not just that Keystone answers.
+# Keystone comes up partway through stack.sh, so this must span the rest of stack.sh plus the admin
+# steps.
+echo "waiting for CI user auth (confirms full DevStack setup has completed) ..."
+for i in $(seq 1 30); do
   payload=$(jq -n \
     --arg user    "${OS_USERNAME}" \
     --arg pass    "${OS_PASSWORD}" \

--- a/ci/terraform/ci/gcp-devstack/install-devstack.sh
+++ b/ci/terraform/ci/gcp-devstack/install-devstack.sh
@@ -131,8 +131,14 @@ register_volumev3_alias() {
   fi
 }
 
-create_project_and_user() {
+create_project() {
   os_admin project show "${OS_PROJECT}" >/dev/null 2>&1 || os_admin project create --domain "${OS_DOMAIN}" "${OS_PROJECT}"
+}
+
+create_user_and_roles() {
+  # Runs last in main(): CI-user auth (which wait-for-devstack polls) only succeeds once every
+  # preceding setup step — flavors, project, quotas — has completed. Auth success therefore means
+  # the cloud is fully ready, not merely that Keystone is answering.
   os_admin user show "${OS_USERNAME}" >/dev/null 2>&1 || \
     os_admin user create --domain "${OS_DOMAIN}" --password "${OS_PASSWORD}" "${OS_USERNAME}"
   os_admin role add --project "${OS_PROJECT}" --user "${OS_USERNAME}" member || true
@@ -155,18 +161,6 @@ bump_quotas() {
     --volumes 20 --gigabytes 200 \
     --networks 20 --subnets 40 --ports 100 --routers 20 --floating-ips 20 --secgroups 40 \
     "${OS_PROJECT}"
-}
-
-upload_jammy_stemcell() {
-  # The lifecycle suite uploads its own stemcell via the CPI; BATS needs the Jammy image present in
-  # Glance for the director/deployment stemcell. Skip if STEMCELL_IMAGE_PATH not provided.
-  if [[ -n "${STEMCELL_IMAGE_PATH:-}" && -f "${STEMCELL_IMAGE_PATH}" ]]; then
-    os_admin image show bosh-openstack-kvm-ubuntu-jammy-go_agent >/dev/null 2>&1 || \
-      os_admin image create --disk-format qcow2 --container-format bare \
-        --file "${STEMCELL_IMAGE_PATH}" bosh-openstack-kvm-ubuntu-jammy-go_agent
-  else
-    log "STEMCELL_IMAGE_PATH not set; skipping Glance stemcell upload (lifecycle uploads its own)."
-  fi
 }
 
 emit_metadata() {
@@ -196,10 +190,10 @@ main() {
   run_stack
   configure_offbox_floating_access
   register_volumev3_alias
+  create_project
   create_flavors
   bump_quotas
-  upload_jammy_stemcell
-  create_project_and_user
+  create_user_and_roles
   emit_metadata
   log "DevStack ready."
 }

--- a/ci/terraform/ci/gcp-devstack/install-devstack.sh
+++ b/ci/terraform/ci/gcp-devstack/install-devstack.sh
@@ -141,8 +141,12 @@ create_user_and_roles() {
   # the cloud is fully ready, not merely that Keystone is answering.
   os_admin user show "${OS_USERNAME}" >/dev/null 2>&1 || \
     os_admin user create --domain "${OS_DOMAIN}" --password "${OS_PASSWORD}" "${OS_USERNAME}"
-  os_admin role add --project "${OS_PROJECT}" --user "${OS_USERNAME}" member || true
-  os_admin role add --project "${OS_PROJECT}" --user "${OS_USERNAME}" admin || true
+  local role
+  for role in member admin; do
+    os_admin role assignment list --project "${OS_PROJECT}" --user "${OS_USERNAME}" --names -f value -c Role \
+      | grep -qx "${role}" \
+      || os_admin role add --project "${OS_PROJECT}" --user "${OS_USERNAME}" "${role}"
+  done
 }
 
 create_flavors() {


### PR DESCRIPTION
Split project creation (needed early for bump_quotas) from user+role creation, which now runs last in main(). CI-user auth in wait-for-devstack only succeeds once every preceding setup step has completed, so a 201 confirms the cloud is fully ready rather than just that Keystone is answering. Drop the dead upload_jammy_stemcell function (STEMCELL_IMAGE_PATH was never set; lifecycle uploads its own stemcell and BATS uploads via the director).