### PR TITLE
CI: Improve Go test suite: order-independence, race detection, and coverage

### DIFF
--- a/ci/tasks/run-golang-integration-specs.sh
+++ b/ci/tasks/run-golang-integration-specs.sh
@@ -2,4 +2,4 @@
 set -eu -o pipefail
 
 cd bosh-openstack-cpi-release/src/openstack_cpi_golang
-go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all --randomize-suites integration
+go run github.com/onsi/ginkgo/v2/ginkgo -r -v --race --randomize-all --randomize-suites integration

--- a/ci/tasks/run-golang-integration-specs.sh
+++ b/ci/tasks/run-golang-integration-specs.sh
@@ -2,4 +2,4 @@
 set -eu -o pipefail
 
 cd bosh-openstack-cpi-release/src/openstack_cpi_golang
-go test ./integration/...
+go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all --randomize-suites integration

--- a/ci/tasks/run-golang-integration-specs.sh
+++ b/ci/tasks/run-golang-integration-specs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+cd bosh-openstack-cpi-release/src/openstack_cpi_golang
+go test ./integration/...

--- a/ci/tasks/run-golang-integration-specs.yml
+++ b/ci/tasks/run-golang-integration-specs.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: ghcr.io/cloudfoundry/bosh/golang-release
+
+inputs:
+- name: bosh-openstack-cpi-release
+
+run:
+  path: bosh-openstack-cpi-release/ci/tasks/run-golang-integration-specs.sh

--- a/ci/tasks/run-golang-unit-specs.sh
+++ b/ci/tasks/run-golang-unit-specs.sh
@@ -2,4 +2,4 @@
 set -eu -o pipefail
 
 cd bosh-openstack-cpi-release/src/openstack_cpi_golang
-go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all --randomize-suites cpi
+go run github.com/onsi/ginkgo/v2/ginkgo -r -v --race --randomize-all --randomize-suites cpi

--- a/ci/tasks/run-golang-unit-specs.sh
+++ b/ci/tasks/run-golang-unit-specs.sh
@@ -2,4 +2,4 @@
 set -eu -o pipefail
 
 cd bosh-openstack-cpi-release/src/openstack_cpi_golang
-go test ./cpi/...
+go run github.com/onsi/ginkgo/v2/ginkgo -r --race --randomize-all --randomize-suites cpi

--- a/src/openstack_cpi_golang/cpi/compute/flavor_resolver_test.go
+++ b/src/openstack_cpi_golang/cpi/compute/flavor_resolver_test.go
@@ -77,6 +77,30 @@ var _ = Describe("FlavorResolver", func() {
 		})
 	})
 
+	Context("GetFlavorById", func() {
+		It("returns the flavor matching the id", func() {
+			flavor, err := compute.NewFlavorResolver(serviceClients, &computeFacade).GetFlavorById("the_flavor_id")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(flavor.ID).To(Equal("the_flavor_id"))
+			Expect(flavor.Name).To(Equal("the_instance_type"))
+		})
+
+		It("returns an error if the flavor id is not found", func() {
+			_, err := compute.NewFlavorResolver(serviceClients, &computeFacade).GetFlavorById("not_existing_flavor_id")
+
+			Expect(err.Error()).To(ContainSubstring("flavor for id 'not_existing_flavor_id' not found"))
+		})
+
+		It("returns an error if flavors cannot be retrieved", func() {
+			computeFacade.ListFlavorsReturns(nil, errors.New("boom"))
+
+			_, err := compute.NewFlavorResolver(serviceClients, &computeFacade).GetFlavorById("the_flavor_id")
+
+			Expect(err.Error()).To(ContainSubstring("failed to get flavors: failed to list flavors: boom"))
+		})
+	})
+
 	Context("ResolveFlavorForRequirements", func() {
 		var vmResources apiv1.VMResources
 		var bootFromVolume bool

--- a/src/openstack_cpi_golang/cpi/methods/delete_stemcell_test.go
+++ b/src/openstack_cpi_golang/cpi/methods/delete_stemcell_test.go
@@ -23,6 +23,7 @@ var _ = Describe("DeleteStemcellMethod", func() {
 		BeforeEach(func() {
 			imageServiceBuilder = imagefakes.FakeImageServiceBuilder{}
 			logger = utilsfakes.FakeLogger{}
+			imageService = imagefakes.FakeImageService{}
 		})
 
 		It("deletes an image ID", func() {

--- a/src/openstack_cpi_golang/cpi/network/network_config_builder_test.go
+++ b/src/openstack_cpi_golang/cpi/network/network_config_builder_test.go
@@ -32,33 +32,6 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("NewNetworkConfig", func() {
-		BeforeEach(func() {
-			networkingConfig, _ = createNetworkConfig(&securityGroupsResolver, //nolint:errcheck
-				[]byte(`{
-				"name1": {
-					"type":    "manual",
-					"ip":      "1.1.1.1",
-					"default": ["gateway"],
-					"cloud_properties": {"net_id": "the_net_id_1", "security_groups": ["security_group_1", "security_group_2"]}
-				},
-				"name2": {
-					"type":    "manual",
-					"ip":      "2.2.2.2",
-					"cloud_properties": {"net_id": "the_net_id_2"}
-				},
-				"name3": {
-					"type":    "vip",
-					"ip":      "3.3.3.3",
-					"cloud_properties": {"net_id": "the_net_id_3", "security_groups": ["security_group_3"]}
-				},
-				"name4": {
-					"type":    "dynamic",
-					"ip":      "4.4.4.4",
-					"cloud_properties": {"net_id": "the_net_id_4", "security_groups": ["security_group_4"]}
-				}
-			}`), openstackConfig, cloudProperties, logger)
-		})
-
 		It("returns an error if a manual network is missing a netid", func() {
 			_, err := createNetworkConfig(&securityGroupsResolver, []byte(`{
 				"name1": {
@@ -146,6 +119,10 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("DefaultNetwork", func() {
+		BeforeEach(func() {
+			networkingConfig = standardNetworkConfig(&securityGroupsResolver, openstackConfig, cloudProperties, logger)
+		})
+
 		It("returns the default network", func() {
 			defaultNetwork := networkingConfig.DefaultNetwork
 
@@ -166,6 +143,10 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("GetManualNetworks", func() {
+		BeforeEach(func() {
+			networkingConfig = standardNetworkConfig(&securityGroupsResolver, openstackConfig, cloudProperties, logger)
+		})
+
 		It("returns the manual networks", func() {
 			manualNetworks := sortNetworks(networkingConfig.ManualNetworks)
 
@@ -180,6 +161,10 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("GetVIPNetwork", func() {
+		BeforeEach(func() {
+			networkingConfig = standardNetworkConfig(&securityGroupsResolver, openstackConfig, cloudProperties, logger)
+		})
+
 		It("returns the vip network", func() {
 			vipNetwork := networkingConfig.VIPNetwork
 
@@ -190,6 +175,10 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("GetDynamicNetwork", func() {
+		BeforeEach(func() {
+			networkingConfig = standardNetworkConfig(&securityGroupsResolver, openstackConfig, cloudProperties, logger)
+		})
+
 		It("returns the dynamic network", func() {
 			dynamicNetwork := networkingConfig.DynamicNetwork
 
@@ -321,6 +310,34 @@ func createNetworkConfig(securityGroupsResolver network.SecurityGroupsResolver, 
 	networkConfig, err := network.NewNetworkConfigBuilder(securityGroupsResolver, networks, openstackConfig, cloudProperties, logger).Build()
 
 	return networkConfig, err
+}
+
+func standardNetworkConfig(securityGroupsResolver network.SecurityGroupsResolver, openstackConfig config.OpenstackConfig, cloudProperties properties.CreateVM, logger utils.Logger) properties.NetworkConfig {
+	networkingConfig, _ := createNetworkConfig(securityGroupsResolver, //nolint:errcheck
+		[]byte(`{
+			"name1": {
+				"type":    "manual",
+				"ip":      "1.1.1.1",
+				"default": ["gateway"],
+				"cloud_properties": {"net_id": "the_net_id_1", "security_groups": ["security_group_1", "security_group_2"]}
+			},
+			"name2": {
+				"type":    "manual",
+				"ip":      "2.2.2.2",
+				"cloud_properties": {"net_id": "the_net_id_2"}
+			},
+			"name3": {
+				"type":    "vip",
+				"ip":      "3.3.3.3",
+				"cloud_properties": {"net_id": "the_net_id_3", "security_groups": ["security_group_3"]}
+			},
+			"name4": {
+				"type":    "dynamic",
+				"ip":      "4.4.4.4",
+				"cloud_properties": {"net_id": "the_net_id_4", "security_groups": ["security_group_4"]}
+			}
+		}`), openstackConfig, cloudProperties, logger)
+	return networkingConfig
 }
 
 func sortSecurityGroups(securityGroups []string) []string {

--- a/src/openstack_cpi_golang/integration/create_disk_test.go
+++ b/src/openstack_cpi_golang/integration/create_disk_test.go
@@ -10,7 +10,15 @@ import (
 )
 
 var _ = Describe("Create Disk", func() {
-	callCount := 0
+	mockVolumeStatus := func(status string) {
+		Mux.HandleFunc("/v3/volumes/2b955850-f177-45f7-9f49-ecb2c256d161", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, //nolint:errcheck
+					`{"volume": {"id": "2b955850-f177-45f7-9f49-ecb2c256d161", "status": "%s"}}`, status)
+			}
+		})
+	}
 
 	BeforeEach(func() {
 		SetupHTTP()
@@ -45,32 +53,6 @@ var _ = Describe("Create Disk", func() {
 				}`)
 			}
 		})
-
-		Mux.HandleFunc("/v3/volumes/2b955850-f177-45f7-9f49-ecb2c256d161", func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet:
-				callCount++
-				if callCount == 1 {
-					w.WriteHeader(http.StatusOK)
-					fmt.Fprintf(w, //nolint:errcheck
-						`{
-					"volume": {
-						"id": "2b955850-f177-45f7-9f49-ecb2c256d161",
-						"status": "available"        				
-					}
-					}`)
-				} else {
-					w.WriteHeader(http.StatusOK)
-					fmt.Fprintf(w, //nolint:errcheck
-						`{
-					"volume": {
-						"id": "2b955850-f177-45f7-9f49-ecb2c256d161",
-						"status": "error"        				
-					}
-					}`)
-				}
-			}
-		})
 	})
 
 	AfterEach(func() {
@@ -78,6 +60,8 @@ var _ = Describe("Create Disk", func() {
 	})
 
 	It("creates a volume", func() {
+		mockVolumeStatus("available")
+
 		writeJsonParamToStdIn(`{
 			"method": "create_disk",
 			"arguments": [
@@ -100,6 +84,8 @@ var _ = Describe("Create Disk", func() {
 
 	Context("when the volume creation fails", func() {
 		It("fails when creating a volume", func() {
+			mockVolumeStatus("error")
+
 			writeJsonParamToStdIn(`{
 			"method": "create_disk",
 			"arguments": [

--- a/src/openstack_cpi_golang/integration/delete_disk_test.go
+++ b/src/openstack_cpi_golang/integration/delete_disk_test.go
@@ -10,40 +10,32 @@ import (
 )
 
 var _ = Describe("Delete Disk", func() {
-	var callCount = 0
+	// mockVolumeStatuses returns firstStatus on the first GET and restStatus on
+	// every subsequent GET, modelling the volume state transition during deletion.
+	// The counter is local to each invocation, so specs stay order-independent.
+	mockVolumeStatuses := func(firstStatus, restStatus string) {
+		callCount := 0
+		Mux.HandleFunc("/v3/volumes/volume_id", func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				callCount++
+				status := restStatus
+				if callCount == 1 {
+					status = firstStatus
+				}
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, //nolint:errcheck
+					`{"volume": {"id": "volume_id", "status": "%s"}}`, status)
+			case http.MethodDelete:
+				w.WriteHeader(http.StatusAccepted)
+			}
+		})
+	}
 
 	BeforeEach(func() {
 		SetupHTTP()
 
 		MockAuthentication()
-
-		Mux.HandleFunc("/v3/volumes/volume_id", func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet:
-				callCount++
-				if callCount == 1 {
-					w.WriteHeader(http.StatusOK)
-					fmt.Fprintf(w, //nolint:errcheck
-						`{
-					"volume": {
-						"id": "volume_id",
-						"status": "available"
-					}
-					}`)
-				} else {
-					w.WriteHeader(http.StatusOK)
-					fmt.Fprintf(w, //nolint:errcheck
-						`{
-					"volume": {
-						"id": "volume_id",
-						"status": "deleted"
-					}
-					}`)
-				}
-			case http.MethodDelete:
-				w.WriteHeader(http.StatusAccepted)
-			}
-		})
 	})
 
 	AfterEach(func() {
@@ -51,6 +43,8 @@ var _ = Describe("Delete Disk", func() {
 	})
 
 	It("deletes a volume", func() {
+		mockVolumeStatuses("available", "deleted")
+
 		writeJsonParamToStdIn(`{
 			"method": "delete_disk",
 			"arguments": [
@@ -68,6 +62,8 @@ var _ = Describe("Delete Disk", func() {
 
 	Context("when the volume deletion fails", func() {
 		It("fails when deleting a volume", func() {
+			mockVolumeStatuses("deleted", "deleted")
+
 			writeJsonParamToStdIn(`{
 				"method": "delete_disk",
 				"arguments": [

--- a/src/openstack_cpi_golang/integration/detach_disk_test.go
+++ b/src/openstack_cpi_golang/integration/detach_disk_test.go
@@ -15,6 +15,7 @@ var _ = Describe("DetachDiskMethod Integration Tests", func() {
 	detachResultSuccess := true
 
 	BeforeEach(func() {
+		detachResultSuccess = true
 		SetupHTTP()
 		MockAuthentication()
 


### PR DESCRIPTION
## Summary

Runs the Go unit and integration specs through the `ginkgo` CLI with the race detector and randomized spec/suite order (matching the conventions in `bosh-dns-release` and `bosh-google-cpi-release`). Enabling randomization surfaced several pre-existing order-dependent tests, which are fixed here so the suites pass deterministically regardless of order.

No production code is changed - this is test-suite and CI-task only.

## Motivation

The Go specs previously ran via `go test ./...`, which runs specs in file order. That masked tests that only passed because of the order they happened to run in (shared mutable state leaking between specs). Randomized order + `--race` is the standard across the BOSH Go repos and catches exactly these latent bugs.

## Changes

### CI task runner

- `run-golang-unit-specs` now runs `ginkgo -r --race --randomize-all --randomize-suites cpi` (prettier per-suite output, race detection, randomized order).
- Added an equivalent `run-golang-integration-specs` task.

### Unit test order-independence

- **network_config_builder**: the `GetManualNetworks` / `GetVIPNetwork` / `GetDynamicNetwork` / `DefaultNetwork` contexts read a shared `networkingConfig` that was only populated by a *sibling* context's `BeforeEach` running first. Replaced the file-order dependency with a `standardNetworkConfig` helper and per-context setup.
- **delete_stemcell**: the `imageService` fake was not reset in `BeforeEach`, so its call count accumulated across specs. Reset it like the other fakes.

### Integration test order-independence

- **create_disk / delete_disk**: specs shared a `Describe`-scope call counter that returned different volume statuses per call, so one spec depended on another having incremented it first. Replaced with a per-spec status helper (delete keeps the `available -> deleted` transition with a local counter).
- **detach_disk**: the failure spec set `detachResultSuccess = false` and never reset it, breaking the success spec when it ran afterwards. Reset it in `BeforeEach`.

### Coverage

- Added tests for `flavorResolver.GetFlavorById` (match, not-found, and flavor-retrieval error) — the only meaningful untested logic found.

## Verification

Both suites pass with `--race --randomize-all --randomize-suites` across multiple seeds:

```
ginkgo -r --race --randomize-all --randomize-suites cpi          # unit
ginkgo -r --race --randomize-all --randomize-suites integration  # integration
```

## Coverage note

Real business-logic coverage is **95.3%**. The naive all-package figure (~61%) is misleading because generated counterfeiter fakes are counted as source. If a coverage gate is ever added, exclude `*fakes` / `mocks` packages so the number reflects actual code. The remaining sub-100% spots are low value (the `CreateVM` V1 no-op stub, `logger.Error` / `HandlePanic`, generated code).
