### PR TITLE
CI: Quiet integration test output

### DIFF
--- a/src/openstack_cpi_golang/integration/integration_suite_test.go
+++ b/src/openstack_cpi_golang/integration/integration_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -25,7 +24,7 @@ func TestIntegration(t *testing.T) {
 
 var defaultConfig config.CpiConfig
 var bootFromVolumeConfig config.CpiConfig
-var logger = utils.NewLogger(boshlog.NewWriterLogger(boshlog.LevelDebug, os.Stderr))
+var logger = utils.NewLogger(boshlog.NewWriterLogger(boshlog.LevelError, os.Stderr))
 var Mux *http.ServeMux
 var Server *httptest.Server
 var originalStdin *os.File
@@ -87,12 +86,7 @@ func getBootFromVolumeConfig(url string) config.CpiConfig {
 func SetupHTTP() {
 	Mux = http.NewServeMux()
 
-	loggingMux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Mux.ServeHTTP(w, r)
-		log.Printf("Received request: %s %s\n", r.Method, r.URL.String())
-	})
-
-	Server = httptest.NewServer(loggingMux)
+	Server = httptest.NewServer(Mux)
 }
 
 func Endpoint() string {


### PR DESCRIPTION
The integration specs ran the CPI at LevelDebug and logged every mock request to stderr, producing thousands of lines of noise per run (and especially under ginkgo -v). Drop the CPI logger to LevelError and remove the per-request mock logging; failures still surface via the response JSON and assertion diffs.