### PR TITLE
Fix inverted config_drive guard for multi-manual-network VMs

### DIFF
--- a/src/openstack_cpi_golang/cpi/network/network_config_builder.go
+++ b/src/openstack_cpi_golang/cpi/network/network_config_builder.go
@@ -139,7 +139,7 @@ func (b networkConfigBuilder) createManualNetwork(networks apiv1.Networks, opens
 	}
 
 	if len(manualNetworks) > 1 {
-		if openstackConfig.UseDHCP || openstackConfig.ConfigDrive != "" {
+		if openstackConfig.UseDHCP || openstackConfig.ConfigDrive == "" {
 			return []properties.Network{}, fmt.Errorf("multiple manual networks can only be used with 'openstack.use_dhcp=false' and 'openstack.config_drive=cdrom|disk'")
 		}
 	}

--- a/src/openstack_cpi_golang/cpi/network/network_config_builder_test.go
+++ b/src/openstack_cpi_golang/cpi/network/network_config_builder_test.go
@@ -25,13 +25,38 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	var logger utils.Logger
 
 	BeforeEach(func() {
-		openstackConfig = config.OpenstackConfig{}
+		openstackConfig = config.OpenstackConfig{ConfigDrive: "cdrom"}
 		cloudProperties = properties.CreateVM{}
 		securityGroupsResolver = networkfakes.FakeSecurityGroupsResolver{}
 		logger = &utilsfakes.FakeLogger{}
+		networkingConfig, _ = createNetworkConfig(&securityGroupsResolver, //nolint:errcheck
+			[]byte(`{
+			"name1": {
+				"type":    "manual",
+				"ip":      "1.1.1.1",
+				"default": ["gateway"],
+				"cloud_properties": {"net_id": "the_net_id_1", "security_groups": ["security_group_1", "security_group_2"]}
+			},
+			"name2": {
+				"type":    "manual",
+				"ip":      "2.2.2.2",
+				"cloud_properties": {"net_id": "the_net_id_2"}
+			},
+			"name3": {
+				"type":    "vip",
+				"ip":      "3.3.3.3",
+				"cloud_properties": {"net_id": "the_net_id_3", "security_groups": ["security_group_3"]}
+			},
+			"name4": {
+				"type":    "dynamic",
+				"ip":      "4.4.4.4",
+				"cloud_properties": {"net_id": "the_net_id_4", "security_groups": ["security_group_4"]}
+			}
+		}`), openstackConfig, cloudProperties, logger)
 	})
 
 	Context("NewNetworkConfig", func() {
+
 		It("returns an error if a manual network is missing a netid", func() {
 			_, err := createNetworkConfig(&securityGroupsResolver, []byte(`{
 				"name1": {
@@ -62,6 +87,23 @@ var _ = Describe("NetworkConfigBuilder", func() {
 					"cloud_properties": {"net_id": "the_net_id_2"}
 				}
 			}`), config.OpenstackConfig{UseDHCP: true}, cloudProperties, logger)
+
+			Expect(err.Error()).To(Equal("invalid manual network configuration: multiple manual networks can only be used with 'openstack.use_dhcp=false' and 'openstack.config_drive=cdrom|disk'"))
+		})
+
+		It("returns an error if multiple manual network exists without config drive set", func() {
+			_, err := createNetworkConfig(&securityGroupsResolver, []byte(`{
+				"name1": {
+					"type":    "manual",
+					"ip":      "",
+					"cloud_properties": {"net_id": "the_net_id_1"}
+				},
+				"name2": {
+					"type":    "manual",
+					"ip":      "",
+					"cloud_properties": {"net_id": "the_net_id_2"}
+				}
+			}`), config.OpenstackConfig{UseDHCP: false}, cloudProperties, logger)
 
 			Expect(err.Error()).To(Equal("invalid manual network configuration: multiple manual networks can only be used with 'openstack.use_dhcp=false' and 'openstack.config_drive=cdrom|disk'"))
 		})
@@ -189,6 +231,9 @@ var _ = Describe("NetworkConfigBuilder", func() {
 	})
 
 	Context("SecurityGroups", func() {
+		BeforeEach(func() {
+			securityGroupsResolver = networkfakes.FakeSecurityGroupsResolver{}
+		})
 		It("returns cloud properties security groups", func() {
 			securityGroupsResolver.ResolveReturns([]string{"resolved_security_group_1", "resolved_security_group_2"}, nil)
 
@@ -292,7 +337,7 @@ var _ = Describe("NetworkConfigBuilder", func() {
 					"ip":      "4.4.4.4",
 					"cloud_properties": {"net_id": "the_net_id_4", "security_groups": ["security_group_4"]}
 				}
-			}`), openstackConfig, cloudProperties, logger)
+			}`), config.OpenstackConfig{ConfigDrive: "cdrom"}, cloudProperties, logger)
 			securityGroups := sortSecurityGroups(networkingConfig.SecurityGroups)
 
 			securityGroupsParam := securityGroupsResolver.ResolveArgsForCall(0)

--- a/src/openstack_cpi_golang/integration/create_vm_test.go
+++ b/src/openstack_cpi_golang/integration/create_vm_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Create VM", func() {
 				Expect(<-outChannel).To(ContainSubstring("multiple manual networks can only be used with"))
 			})
 
-			It("fails if multiple manual networks is used with an non-empty ConfigDrive", func() {
+			It("fails if multiple manual networks is used without config_drive set", func() {
 				writeJsonParamToStdIn(`{
 				"method": "create_vm",
 				"arguments": [
@@ -245,7 +245,6 @@ var _ = Describe("Create VM", func() {
 			}`)
 
 				defaultConfig = getDefaultConfig(Endpoint())
-				defaultConfig.Cloud.Properties.Openstack.ConfigDrive = "cdrom"
 				err := cpi.Execute(defaultConfig, logger)
 				Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
## Problem

When a VM is created with more than one manual network, the Go CPI rejects the request if `config_drive` is **set**, and accepts it if `config_drive` is **absent**. This is the inverse of the intended behaviour and means multi-NIC VMs with `config_drive` can never be created.

### Root cause

`network_config_builder.go` line 142:

```go
// Go CPI (buggy)
if openstackConfig.UseDHCP || openstackConfig.ConfigDrive != "" {
    return error   // fires when config_drive IS set — wrong
}
```

The Ruby CPI reference in `network_configurator.rb`:

```ruby
# Ruby CPI (correct)
if use_dhcp || !config_drive
  raise error   # fires when config_drive is ABSENT — correct
end
```

`!config_drive` (Ruby falsy) maps to `ConfigDrive == ""` in Go. The Go port wrote `!= ""` instead.

## Fix

- `network_config_builder.go`: `ConfigDrive != ""` → `ConfigDrive == ""`
- `integration/create_vm_test.go`: rename the test that encoded the inverted behaviour and remove the erroneous `ConfigDrive = "cdrom"` override, so it now verifies the correct failing case (config_drive absent, use_dhcp false)
- `network_config_builder_test.go`: fix the BeforeEach fixture and the security-groups merge test (both built two-manual-network configs with ConfigDrive unset, relying on the inverted guard); add a second error-path test for `ConfigDrive = ""`