### PR TITLE
Redact application_credential.secret from OpenStack API debug logs

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/excon_logging_instrumentor.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/excon_logging_instrumentor.rb
@@ -31,6 +31,7 @@ module Bosh::OpenStackCloud
         redact_body(redacted_params, 'auth.passwordCredentials.password')
         redact_body(redacted_params, 'server.user_data')
         redact_body(redacted_params, 'auth.identity.password.user.password')
+        redact_body(redacted_params, 'auth.identity.application_credential.secret')
         redact_headers(redacted_params, 'X-Auth-Token')
         redacted_params
       end

--- a/src/bosh_openstack_cpi/spec/unit/excon_logging_instrumentor_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/excon_logging_instrumentor_spec.rb
@@ -195,6 +195,33 @@ describe Bosh::OpenStackCloud::ExconLoggingInstrumentor do
         end
       end
 
+      context 'with application_credential.secret in body' do
+        let(:body) {
+          {
+            auth: {
+              identity: {
+                application_credential: {
+                  secret: 'my-application-credential-secret',
+                },
+              },
+            },
+          } }
+        let(:params) {
+          {
+            body: JSON.dump(body),
+            headers: {
+              'Content-Type' => 'application/json',
+            },
+          } }
+
+        it 'redacts application_credential.secret' do
+          redacted_params = subject.redact(params)
+
+          parsed_body = JSON.parse(redacted_params[:body])
+          expect(parsed_body['auth']['identity']['application_credential']['secret']).to eq('<redacted>')
+        end
+      end
+
       context 'with server.user_data in body' do
         let(:body) {
           {


### PR DESCRIPTION
ExconLoggingInstrumentor.redact did not scrub the application credential secret from Keystone auth request bodies, causing it to appear in BOSH task debug logs when application credential auth was in use.