### PR TITLE
Fix loadbalancer service build

### DIFF
--- a/src/openstack_cpi_golang/cpi/methods/create_vm.go
+++ b/src/openstack_cpi_golang/cpi/methods/create_vm.go
@@ -83,9 +83,12 @@ func (m CreateVMMethod) CreateVMV2(
 		return apiv1.VMCID{}, apiv1.Networks{}, fmt.Errorf("failed to create image service: %w", err)
 	}
 
-	loadbalancerService, err := m.loadbalancerServiceBuilder.Build()
-	if err != nil {
-		return apiv1.VMCID{}, apiv1.Networks{}, fmt.Errorf("failed to create loadbalancer service: %w", err)
+	var loadbalancerService loadbalancer.LoadbalancerService
+	if len(cloudProps.LoadbalancerPools) > 0 {
+		loadbalancerService, err = m.loadbalancerServiceBuilder.Build()
+		if err != nil {
+			return apiv1.VMCID{}, apiv1.Networks{}, fmt.Errorf("failed to create loadbalancer service: %w", err)
+		}
 	}
 
 	_, err = imageService.GetImage(stemcellCID.AsString())

--- a/src/openstack_cpi_golang/cpi/methods/create_vm_test.go
+++ b/src/openstack_cpi_golang/cpi/methods/create_vm_test.go
@@ -258,7 +258,7 @@ var _ = Describe("CreateVMMethod", func() {
 						"availability_zones": ["z1", "z2"]
 					}`
 
-				_, _, _ = methods.NewCreateVMMethod( //nolint:errcheck
+				_, _, err := methods.NewCreateVMMethod(
 					&imageServiceBuilder,
 					&networkServiceBuilder,
 					&computeServiceBuilder,
@@ -274,6 +274,7 @@ var _ = Describe("CreateVMMethod", func() {
 					env,
 				)
 
+				Expect(err).ToNot(HaveOccurred())
 				Expect(loadbalancerServiceBuilder.BuildCallCount()).To(Equal(0))
 			})
 

--- a/src/openstack_cpi_golang/cpi/methods/create_vm_test.go
+++ b/src/openstack_cpi_golang/cpi/methods/create_vm_test.go
@@ -252,6 +252,31 @@ var _ = Describe("CreateVMMethod", func() {
 				Expect(loadbalancerServiceBuilder.BuildCallCount()).To(Equal(1))
 			})
 
+			It("does not build the loadbalancer service if no loadbalancer_pools are configured", func() {
+				jsonStr = `{
+						"instance_type": "type1",
+						"availability_zones": ["z1", "z2"]
+					}`
+
+				_, _, _ = methods.NewCreateVMMethod( //nolint:errcheck
+					&imageServiceBuilder,
+					&networkServiceBuilder,
+					&computeServiceBuilder,
+					&loadbalancerServiceBuilder,
+					cpiConfig,
+					&logger,
+				).CreateVMV2(
+					apiv1.NewAgentID("the_agent-id"),
+					apiv1.NewStemcellCID("stemcell-id"),
+					apiv1.CloudPropsImpl{RawMessage: []byte(jsonStr)},
+					networks,
+					[]apiv1.DiskCID{},
+					env,
+				)
+
+				Expect(loadbalancerServiceBuilder.BuildCallCount()).To(Equal(0))
+			})
+
 			It("returns an error if the loadbalancer service cannot be retrieved", func() {
 				loadbalancerServiceBuilder.BuildReturns(nil, errors.New("boom"))
 

--- a/src/openstack_cpi_golang/cpi/methods/delete_vm.go
+++ b/src/openstack_cpi_golang/cpi/methods/delete_vm.go
@@ -60,13 +60,15 @@ func (a DeleteVMMethod) DeleteVM(cid apiv1.VMCID) error {
 	}
 
 	if len(serverMetadata) > 0 {
-		loadbalancerService, err := a.loadbalancerServiceBuilder.Build()
-		if err != nil {
-			return fmt.Errorf("delete_vm: %w", err)
-		}
-
+		var loadbalancerService loadbalancer.LoadbalancerService
 		for key, value := range serverMetadata {
 			if strings.HasPrefix(key, "lbaas_pool_") {
+				if loadbalancerService == nil {
+					loadbalancerService, err = a.loadbalancerServiceBuilder.Build()
+					if err != nil {
+						return fmt.Errorf("delete_vm: %w", err)
+					}
+				}
 				parts := strings.Split(value, "/")
 				err = loadbalancerService.DeletePoolMember(parts[0], parts[1], a.cpiConfig.Cloud.Properties.Openstack.StateTimeOut)
 				if err != nil {

--- a/src/openstack_cpi_golang/cpi/methods/delete_vm_test.go
+++ b/src/openstack_cpi_golang/cpi/methods/delete_vm_test.go
@@ -222,6 +222,25 @@ var _ = Describe("DeleteVMMethod", func() {
 			Expect(computeService.DeleteServerCallCount()).To(Equal(1))
 		})
 
+		It("does not build the loadbalancer service if metadata has no 'lbaas_pool_' tags", func() {
+			computeService.GetMetadataReturns(map[string]string{"tag1": "tag1Value"}, nil)
+
+			err := methods.NewDeleteVMMethod(
+				&networkServiceBuilder,
+				&computeServiceBuilder,
+				&loadbalancerServiceBuilder,
+				config.CpiConfig{},
+				&logger,
+			).DeleteVM(
+				apiv1.NewVMCID("vm-id"),
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(loadbalancerServiceBuilder.BuildCallCount()).To(Equal(0))
+			Expect(loadbalancerService.DeletePoolMemberCallCount()).To(Equal(0))
+			Expect(computeService.DeleteServerCallCount()).To(Equal(1))
+		})
+
 		It("deletes a pool member for tags with prefix 'lbaas_pool_'", func() {
 			err := methods.NewDeleteVMMethod(
 				&networkServiceBuilder,


### PR DESCRIPTION
The Go CPI was unconditionally building a `LoadbalancerService` on every `create_vm` and `delete_vm` call, even when no `loadbalancer_pools` are configured. This caused unnecessary service instantiation and potential errors in environments without LBaaS.

- `create_vm`: skip loadbalancer pool registration when `loadbalancer_pools` cloud property is absent or empty
- `delete_vm`: skip loadbalancer pool deregistration when no `lbaas_pool` metadata exists on the VM
- Added unit tests covering both code paths

This was discovered on the Concourse pipelines, since the DevStack environment there does not provide Octavia.