### PR TITLE
CI: Slim down CI docker image

### DIFF
--- a/ci/docker/openstack-cpi-release/Dockerfile
+++ b/ci/docker/openstack-cpi-release/Dockerfile
@@ -1,56 +1,29 @@
-FROM ubuntu:jammy
+FROM ubuntu
 
-ENV bosh_cli_version 7.7.2
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV BOSH_CLI_VERSION=7.10.10
 
-RUN apt-get -y update && apt-get install -y locales && locale-gen en_US.UTF-8
-RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN apt-get -y update \
+    && apt-get install -y --no-install-recommends \
+        locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
-RUN apt-get install -y \
-    sudo \
-    apt-utils \
-    curl wget tar make uuid-runtime \
-    sqlite3 libsqlite3-dev \
-    mysql-client libmysqlclient-dev \
-    postgresql postgresql-client libpq-dev \
-    build-essential checkinstall \
-    libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev \
-    whois \
-    netcat \
-    python3 \
-    python3-pip \
-    libyaml-dev jq && \
-    apt-get clean
+# ruby needed for BATS (bosh-acceptance-tests is an RSpec suite)
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    git-lfs \
+    jq \
+    openssh-client \
+    ruby \
+    ruby-bundler \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pytz && pip3 install pyrsistent python-openstackclient && \
-    pip3 install awscli
-
-# install newest git CLI
-RUN apt-get install software-properties-common -y; \
-    add-apt-repository ppa:git-core/ppa -y; \
-    apt-get update; \
-    apt-get install -y git git-lfs
-
-# ruby-install
-RUN mkdir /tmp/ruby-install && \
-    cd /tmp/ruby-install && \
-    curl https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.8.3 | tar -xz && \
-    cd /tmp/ruby-install/ruby-install-0.8.3 && \
-    make install && \
-    rm -rf /tmp/ruby-install
-
-#Ruby
-RUN ruby-install --system ruby 3.1.0
-
-#BOSH CLI
-RUN curl -sL https://github.com/cloudfoundry/bosh-cli/releases/download/v${bosh_cli_version}/bosh-cli-${bosh_cli_version}-linux-amd64 \
+RUN curl -fsSL "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64" \
     > /usr/bin/bosh \
-    && chmod +x /usr/bin/bosh && \
-    cp /usr/bin/bosh /usr/local/bin/bosh-go
-
-#GitHub CLI
-RUN cd /tmp && \
-    curl -L https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz | tar -xz && \
-    cp hub-linux-amd64-2.14.2/bin/hub /usr/local/bin && \
-    rm -rf /tmp/hub-linux-amd64-2.14.2 && \
-    rm -f /tmp/hub-linux-amd64-2.14.2.tgz
+    && chmod +x /usr/bin/bosh \
+    && cp /usr/bin/bosh /usr/local/bin/bosh-go

--- a/ci/docker/openstack-cpi-release/Dockerfile
+++ b/ci/docker/openstack-cpi-release/Dockerfile
@@ -6,24 +6,25 @@ ENV BOSH_CLI_VERSION=7.10.10
 
 RUN apt-get -y update \
     && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        git-lfs \
+        jq \
         locales \
+        openssh-client \
+        ruby \
+        ruby-bundler \
+        ruby-dev \
     && locale-gen en_US.UTF-8 \
-    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-
-# ruby needed for BATS (bosh-acceptance-tests is an RSpec suite)
-RUN apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    git-lfs \
-    jq \
-    openssh-client \
-    ruby \
-    ruby-bundler \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64" \
-    > /usr/bin/bosh \
+    > /tmp/bosh \
+    && echo "ff092e567f6b6b41cbcaf8b4065eb2bae29a7463f537bd99ae6424c0d93291c9  /tmp/bosh" | sha256sum -c - \
+    && mv /tmp/bosh /usr/bin/bosh \
     && chmod +x /usr/bin/bosh \
     && cp /usr/bin/bosh /usr/local/bin/bosh-go

--- a/ci/docker/openstack-cpi-release/Dockerfile
+++ b/ci/docker/openstack-cpi-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC


### PR DESCRIPTION
drop Python, DB clients, ruby-install; use system Ruby, bump BOSH CLI to 7.10.10