### PR TITLE
Fix go CPI logger and config

### DIFF
--- a/src/openstack_cpi_golang/cpi/config/config.go
+++ b/src/openstack_cpi_golang/cpi/config/config.go
@@ -31,29 +31,29 @@ type Properties struct {
 }
 
 type OpenstackConfig struct {
-	AuthURL                      string                 `json:"auth_url"`
-	Username                     string                 `json:"username"`
-	APIKey                       string                 `json:"api_key"`
-	ApplicationCredentialID      string                 `json:"application_credential_id"`
-	ApplicationCredentialSecret  string                 `json:"application_credential_secret"`
-	Region                       string                 `json:"region"`
-	EndpointType                 string                 `json:"endpoint_type"`
-	DefaultKeyName               string                 `json:"default_key_name"`
-	DefaultSecurityGroups        []string               `json:"default_security_groups"`
-	DefaultVolumeType            string                 `json:"default_volume_type"`
-	WaitResourcePollInterval     int                    `json:"wait_resource_poll_interval"`
-	BootFromVolume               bool                   `json:"boot_from_volume"`
-	ConfigDrive                  string                 `json:"config_drive"`
-	UseDHCP                      bool                   `json:"use_dhcp"`
-	IgnoreServerAvailabilityZone bool                   `json:"ignore_server_availability_zone"`
-	HumanReadableVMNames         bool                   `json:"human_readable_vm_names"`
-	UseNovaNetworking            bool                   `json:"use_nova_networking"`
-	ConnectionOptions            map[string]interface{} `json:"connection_options"`
-	DomainName                   string                 `json:"domain"`
-	ProjectName                  string                 `json:"project"`
-	Tenant                       string                 `json:"tenant"`
-	StateTimeOut                 int                    `json:"state_timeout"`
-	StemcellPubliclyVisible      bool                   `json:"stemcell_public_visibility"`
+	AuthURL                      string         `json:"auth_url"`
+	Username                     string         `json:"username"`
+	APIKey                       string         `json:"api_key"`
+	ApplicationCredentialID      string         `json:"application_credential_id"`
+	ApplicationCredentialSecret  string         `json:"application_credential_secret"`
+	Region                       string         `json:"region"`
+	EndpointType                 string         `json:"endpoint_type"`
+	DefaultKeyName               string         `json:"default_key_name"`
+	DefaultSecurityGroups        []string       `json:"default_security_groups"`
+	DefaultVolumeType            string         `json:"default_volume_type"`
+	WaitResourcePollInterval     int            `json:"wait_resource_poll_interval"`
+	BootFromVolume               bool           `json:"boot_from_volume"`
+	ConfigDrive                  string         `json:"config_drive"`
+	UseDHCP                      bool           `json:"use_dhcp"`
+	IgnoreServerAvailabilityZone bool           `json:"ignore_server_availability_zone"`
+	HumanReadableVMNames         bool           `json:"human_readable_vm_names"`
+	UseNovaNetworking            bool           `json:"use_nova_networking"`
+	ConnectionOptions            map[string]any `json:"connection_options"`
+	DomainName                   string         `json:"domain"`
+	ProjectName                  string         `json:"project"`
+	Tenant                       string         `json:"tenant"`
+	StateTimeOut                 int            `json:"state_timeout"`
+	StemcellPubliclyVisible      bool           `json:"stemcell_public_visibility"`
 	VM                           struct {
 		Stemcell struct {
 			APIVersion int `json:"api_version"`

--- a/src/openstack_cpi_golang/cpi/config/config.go
+++ b/src/openstack_cpi_golang/cpi/config/config.go
@@ -48,7 +48,7 @@ type OpenstackConfig struct {
 	IgnoreServerAvailabilityZone bool     `json:"ignore_server_availability_zone"`
 	HumanReadableVMNames         bool     `json:"human_readable_vm_names"`
 	UseNovaNetworking            bool     `json:"use_nova_networking"`
-	ConnectionOptions            string   `json:"connection_options"`
+	ConnectionOptions            map[string]interface{} `json:"connection_options"`
 	DomainName                   string   `json:"domain"`
 	ProjectName                  string   `json:"project"`
 	Tenant                       string   `json:"tenant"`

--- a/src/openstack_cpi_golang/cpi/config/config.go
+++ b/src/openstack_cpi_golang/cpi/config/config.go
@@ -31,29 +31,29 @@ type Properties struct {
 }
 
 type OpenstackConfig struct {
-	AuthURL                      string   `json:"auth_url"`
-	Username                     string   `json:"username"`
-	APIKey                       string   `json:"api_key"`
-	ApplicationCredentialID      string   `json:"application_credential_id"`
-	ApplicationCredentialSecret  string   `json:"application_credential_secret"`
-	Region                       string   `json:"region"`
-	EndpointType                 string   `json:"endpoint_type"`
-	DefaultKeyName               string   `json:"default_key_name"`
-	DefaultSecurityGroups        []string `json:"default_security_groups"`
-	DefaultVolumeType            string   `json:"default_volume_type"`
-	WaitResourcePollInterval     int      `json:"wait_resource_poll_interval"`
-	BootFromVolume               bool     `json:"boot_from_volume"`
-	ConfigDrive                  string   `json:"config_drive"`
-	UseDHCP                      bool     `json:"use_dhcp"`
-	IgnoreServerAvailabilityZone bool     `json:"ignore_server_availability_zone"`
-	HumanReadableVMNames         bool     `json:"human_readable_vm_names"`
-	UseNovaNetworking            bool     `json:"use_nova_networking"`
+	AuthURL                      string                 `json:"auth_url"`
+	Username                     string                 `json:"username"`
+	APIKey                       string                 `json:"api_key"`
+	ApplicationCredentialID      string                 `json:"application_credential_id"`
+	ApplicationCredentialSecret  string                 `json:"application_credential_secret"`
+	Region                       string                 `json:"region"`
+	EndpointType                 string                 `json:"endpoint_type"`
+	DefaultKeyName               string                 `json:"default_key_name"`
+	DefaultSecurityGroups        []string               `json:"default_security_groups"`
+	DefaultVolumeType            string                 `json:"default_volume_type"`
+	WaitResourcePollInterval     int                    `json:"wait_resource_poll_interval"`
+	BootFromVolume               bool                   `json:"boot_from_volume"`
+	ConfigDrive                  string                 `json:"config_drive"`
+	UseDHCP                      bool                   `json:"use_dhcp"`
+	IgnoreServerAvailabilityZone bool                   `json:"ignore_server_availability_zone"`
+	HumanReadableVMNames         bool                   `json:"human_readable_vm_names"`
+	UseNovaNetworking            bool                   `json:"use_nova_networking"`
 	ConnectionOptions            map[string]interface{} `json:"connection_options"`
-	DomainName                   string   `json:"domain"`
-	ProjectName                  string   `json:"project"`
-	Tenant                       string   `json:"tenant"`
-	StateTimeOut                 int      `json:"state_timeout"`
-	StemcellPubliclyVisible      bool     `json:"stemcell_public_visibility"`
+	DomainName                   string                 `json:"domain"`
+	ProjectName                  string                 `json:"project"`
+	Tenant                       string                 `json:"tenant"`
+	StateTimeOut                 int                    `json:"state_timeout"`
+	StemcellPubliclyVisible      bool                   `json:"stemcell_public_visibility"`
 	VM                           struct {
 		Stemcell struct {
 			APIVersion int `json:"api_version"`

--- a/src/openstack_cpi_golang/main.go
+++ b/src/openstack_cpi_golang/main.go
@@ -25,18 +25,18 @@ func main() {
 
 	cpiConfig, err := config.NewConfigFromPath(fileSystem, *configPathOpt)
 	if err != nil {
-		cpiLogger.Error("main", "failed loading the configuration: %w", err)
+		cpiLogger.Error("main", "failed loading the configuration: %v", err)
 		os.Exit(1)
 	}
 	err = cpiConfig.Validate()
 	if err != nil {
-		cpiLogger.Error("main", "failed validating the configuration: %w", err)
+		cpiLogger.Error("main", "failed validating the configuration: %v", err)
 		os.Exit(1)
 	}
 
 	err = cpi.Execute(cpiConfig, cpiLogger)
 	if err != nil {
-		cpiLogger.Error("main", "execution failed with: %w", err)
+		cpiLogger.Error("main", "execution failed with: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Replace %w with %v in main.go logger calls - %w is only valid in fmt.Errorf, using it elsewhere produces a literal %!w(...) string in log output
Fix connection_options field type from string to map[string]any - the field is a JSON object, not a string; the previous type caused silent unmarshal failures