### PR TITLE
CI: Fix release-version-semver credentials to allow push

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -620,8 +620,8 @@ resources:
     uri: https://github.com/cloudfoundry/bosh-openstack-cpi-release.git
     branch: release-semver
     file: VERSION
-    username: ((github_read_write_packages.username))
-    password: ((github_read_write_packages.password))
+    username: bosh-admin-bot
+    password: ((github_public_repo_token))
 
 - name: bats
   type: git


### PR DESCRIPTION
The release-semver branch push failed with 403 because the semver resource used github_read_write_packages. Switch to bosh-admin-bot / github_public_repo_token, matching the main git resource.