### PR TITLE
CI: fix promote-candidate release job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -343,7 +343,6 @@ jobs:
         input_mapping:
           input_repo: bosh-openstack-cpi-release
         params:
-          GIT_PRIVATE_KEY: ((github_deploy_key_bosh-openstack-cpi-release.private_key))
           SEVERITY: CRITICAL,HIGH
         on_success:
           do:
@@ -394,9 +393,11 @@ jobs:
       resource: release-version-semver
       trigger: true
     - get: release-notes
+    - get: openstack-cpi-release-docker-image
   - task: promote
     timeout: *timeouts-long
     file: bosh-shared-ci/tasks/release/create-final-release.yml
+    image: openstack-cpi-release-docker-image
     input_mapping:
       release_repo: bosh-openstack-cpi-release
     params:


### PR DESCRIPTION
- Remove stale GIT_PRIVATE_KEY from check-for-patched-cves: the shared bosh-shared-ci task neither declares nor uses it (it deliberately keeps SSH keys away from trivy), and the referenced var is absent from the credential store, causing task-config interpolation to fail.
- Run the promote task under openstack-cpi-release-docker-image instead of the task's default bosh/cli image. The Ruby CPI pre_packaging runs 'bundle package' against a Gemfile.lock bundled with 2.6.9 (Ruby 3.4), which the old bundler in bosh/cli cannot resolve. The CPI image has the matching Ruby/bundler and the bosh CLI.