### PR TITLE
fix broken ci tasks after removal of ruby

### DIFF
--- a/ci/tasks/deploy-manual-networking.sh
+++ b/ci/tasks/deploy-manual-networking.sh
@@ -18,8 +18,6 @@ source bosh-openstack-cpi-release/ci/tasks/utils.sh
 : "${DEBUG_BATS:?}"
 openstack_ca_file_path="${openstack_ca_file_path:-}"
 optional_value availability_zone
-USE_GOLANG_CPI="${USE_GOLANG_CPI:-true}"
-
 # Variables from TF
 export_terraform_variable terraform-cpi/metadata "default_key_name"
 export_terraform_variable terraform-cpi/metadata "openstack_project"
@@ -38,11 +36,6 @@ deployment_dir="${PWD}/bosh-director-deployment"
 
 maybe_use_custom_ca_ops_file=()
 maybe_load_custom_ca_file=()
-maybe_golang_cpi_ops_file=()
-
-if [ "${USE_GOLANG_CPI}" == "true" ]; then
-  maybe_golang_cpi_ops_file=(-o ../bosh-openstack-cpi-release/ci/ops_files/use-golang-cpi.yml)
-fi
 
 case "$openstack_ca_file_path" in
     "")
@@ -77,7 +70,6 @@ bosh-go int ../bosh-deployment/bosh.yml \
     -o ../bosh-deployment/external-ip-not-recommended.yml \
     -o ../bosh-deployment/jumpbox-user.yml \
     -o ../bosh-openstack-cpi-release/ci/ops_files/deployment-configuration.yml \
-    "${maybe_golang_cpi_ops_file[@]}" \
     -o ../bosh-openstack-cpi-release/ci/ops_files/custom-manual-networking.yml \
     -o ../bosh-openstack-cpi-release/ci/ops_files/timeouts.yml \
     -o ../bosh-openstack-cpi-release/ci/ops_files/remove-registry.yml \

--- a/ci/tasks/deploy-manual-networking.yml
+++ b/ci/tasks/deploy-manual-networking.yml
@@ -27,4 +27,3 @@ params:
   DEBUG_BATS:                          ""
   openstack_file_path:                 ""
   availability_zone:                   replace-me
-  USE_GOLANG_CPI:                      "true"


### PR DESCRIPTION
## Fix BATS director deployment after bosh-deployment Go CPI default

Since [bosh-deployment#528](https://github.com/cloudfoundry/bosh-deployment/pull/528), `openstack/cpi.yml` installs `openstack_cpi_golang` by default. The `use-golang-cpi.yml` ops file was written to swap the Ruby job (`openstack_cpi`) for the Go one, but with Go now the default there is no `openstack_cpi` job left to replace — causing the interpolation to fail:
```

Error 'operation [0] in use-golang-cpi.yml failed':
Expected to find exactly one matching array item for path
'/instance_groups/name=bosh/jobs/name=openstack_cpi' but found 0
```
**Changes:**

- Removed `USE_GOLANG_CPI` variable and the `maybe_golang_cpi_ops_file` conditional from `ci/tasks/deploy-manual-networking.sh` — the ops file is a no-op now that Go is the default
- Removed the corresponding `USE_GOLANG_CPI` param from `ci/tasks/deploy-manual-networking.yml`
